### PR TITLE
fix: set login field for bouygues telecom konnector

### DIFF
--- a/src/initKonnectors.json
+++ b/src/initKonnectors.json
@@ -20,7 +20,7 @@
     "category":"telecom",
     "color":{"hex":"#009DCC","css":"#009DCC"},
     "dataType":["bill"],
-    "fields":{"phoneNumber":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
+    "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "source": "git://github.com/cozy/cozy-konnector-bouyguestelecom.git#build"
   },
   {


### PR DESCRIPTION
Bouygues Telecom konnector used phoneNumber field as login field and it does not match with the cozy-collect application at the moment