### PR TITLE
feat: Change default folder name

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,7 +58,7 @@
   "error occurred during import:": "An error occurred during the last import:",
   "import server error": "Server error occured while importing.",
   "open selected folder": "Open selected folder",
-  "konnector default base folder": "/Administration/%{name}",
+  "konnector default base folder": "/Administrative/%{name}",
   "konnector description darty": "Import all your Darty bills in your Cozy.",
   "konnector description malakoff_mederic": "Import your Malakoff Mederic reimbursements in your Cozy.",
   "konnector description meetup": "Synchronize your Meetup calendar with your Cozy. This konnector requires the Calendar application.",


### PR DESCRIPTION
Default folder name for Connectors switches from `Administration` to `Administrative` (in English) and `Administratif` (in French, see transifex).