### PR TITLE
refactor: set account creation logic into AccountConnection component

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -2,6 +2,7 @@ import styles from '../styles/accountLoginForm'
 
 import React from 'react'
 import classNames from 'classnames'
+import statefulForm from '../lib/statefulForm'
 import Field, { PasswordField, DropdownField, CheckboxField } from './Field'
 
 const AccountLoginForm = ({ t, konnector, customView, fields, error, dirty, submitting, onSubmit }) => (
@@ -49,4 +50,4 @@ const AccountLoginForm = ({ t, konnector, customView, fields, error, dirty, subm
   </div>
 )
 
-export default AccountLoginForm
+export default statefulForm()(AccountLoginForm)

--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import statefulForm from '../lib/statefulForm'
 import Field, { PasswordField, DropdownField, CheckboxField } from './Field'
 
-const AccountLoginForm = ({ t, konnector, customView, fields, error, dirty, submitting, onSubmit }) => (
+const AccountLoginForm = ({ t, konnector, customView, fields, error, dirty, submitting, submit }) => (
   <div className={styles['account-form-login']}>
     {customView &&
       <div className='coz-custom-view'
@@ -39,7 +39,7 @@ const AccountLoginForm = ({ t, konnector, customView, fields, error, dirty, subm
         className={classNames('coz-btn', 'coz-btn--regular', styles['col-btn--regular'])}
         disabled={(!dirty && !konnector.oauth) || submitting}
         aria-busy={submitting ? 'true' : 'false'}
-        onClick={onSubmit}
+        onClick={submit}
       >
         {t('account.connection.login.submit')}
       </button>

--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -3,14 +3,13 @@ import React from 'react'
 import AccountConnection from '../../containers/AccountConnection'
 
 const CreateAccountService = (props) => {
-  const { konnector, onSubmit, onOAuth } = props
+  const { konnector, onSubmit } = props
   return (
     <div className='coz-service-content'>
       <AccountConnection
         connector={konnector}
         fields={konnector.fields}
         onSubmit={onSubmit}
-        onOAuth={onOAuth}
         {...props}
         />
     </div>

--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import AccountConnection from '../AccountConnection'
+import AccountConnection from '../../containers/AccountConnection'
 
 const CreateAccountService = (props) => {
   const { konnector, onSubmit, onOAuth } = props

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -83,12 +83,12 @@ class AccountConnection extends Component {
         if (connection.error) {
           this.setState({ error: connection.error.message })
         } else {
-          this.gotoParent()
           if (folderPath) {
             Notifier.info(t('account config success'), t('account config details') + folderPath)
           } else {
             Notifier.info(t('account config success'))
           }
+          this.props.onSuccess(account)
         }
       })
   }

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -45,15 +45,14 @@ class AccountConnection extends Component {
 
   terminateOAuth (accountID) {
     const { t } = this.context
-    const { service } = this.state
-    const data = service.getData()
+    const { slug } = this.props.connector
 
     // update connector to get the new account
     this.setState({submitting: true})
-    this.store.fetchKonnectorInfos(data.slug)
+    this.store.fetchKonnectorInfos(slug)
       .then(konnector => {
         return this.store
-          .fetchAccounts(data.slug, null)
+          .fetchAccounts(slug, null)
           .then(accounts => {
             konnector.accounts = accounts
             const currentIdx = accounts.findIndex(a => a._id === accountID)

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -3,8 +3,8 @@ import styles from '../styles/accountConnection'
 import React, { Component } from 'react'
 import statefulForm from '../lib/statefulForm'
 
-import AccountLoginForm from './AccountLoginForm'
-import DataItem from './DataItem'
+import AccountLoginForm from '../components/AccountLoginForm'
+import DataItem from '../components/DataItem'
 import ReactMarkdown from 'react-markdown'
 
 class AccountConnection extends Component {

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 
 import Modal from 'cozy-ui/react/Modal'
 import ModalContent from 'cozy-ui/react/Modal/Content'
-import AccountConnection from '../components/AccountConnection'
+import AccountConnection from './AccountConnection'
 import AccountManagement from '../components/AccountManagement'
 import Notifier from '../components/Notifier'
 import {popupCenter} from '../lib/popup'

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -107,6 +107,7 @@ export default class ConnectorManagement extends Component {
                 {...this.state}
                 {...this.context} />
               : <AccountConnection
+                connector={this.state.connector}
                 onError={(error) => this.handleError(error)}
                 {...this.state}
                 {...this.context} />

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -109,6 +109,7 @@ export default class ConnectorManagement extends Component {
               : <AccountConnection
                 connector={this.state.connector}
                 onError={(error) => this.handleError(error)}
+                onSuccess={(account) => this.handleSuccess(account)}
                 {...this.state}
                 {...this.context} />
             }
@@ -116,6 +117,10 @@ export default class ConnectorManagement extends Component {
         </Modal>
       )
     }
+  }
+
+  handleSuccess (account) {
+    this.goToParent()
   }
 
   handleError (error) {

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -3,7 +3,6 @@ import React, { Component } from 'react'
 import Loading from '../components/Loading'
 import ServiceBar from '../components/services/ServiceBar'
 import CreateAccountService from '../components/services/CreateAccountService'
-import {popupCenter, waitForClosedPopup} from '../lib/popup'
 
 export default class IntentService extends Component {
   constructor (props, context) {
@@ -11,7 +10,6 @@ export default class IntentService extends Component {
     this.store = context.store
 
     const {window} = props
-    this.terminateOAuth = this.terminateOAuth.bind(this)
 
     this.state = {
       isFetching: true
@@ -55,73 +53,6 @@ export default class IntentService extends Component {
             reason: error.message
           }
         })
-      })
-  }
-
-  createAccount (auth, baseFolder) {
-    const { konnector } = this.state
-    const account = {auth: auth}
-
-    return this.store.connectAccount(konnector, account, baseFolder)
-      .then(connection => this.terminate(connection.account))
-      .catch(error => this.handleError(error))
-  }
-
-  connectAccountOAuth (accountType) {
-    const cozyUrl =
-      `${window.location.protocol}//${document.querySelector('[role=application]').dataset.cozyDomain}`
-    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start`, `${accountType}_oauth`, 800, 800)
-    waitForClosedPopup(newTab, `${accountType}_oauth`)
-    .then(accountID => {
-      this.terminateOAuth(accountID)
-    })
-    .catch(error => {
-      this.setState({submitting: false, error: error.message})
-    })
-  }
-
-  terminateOAuth (accountID) {
-    const { t } = this.context
-    const { service } = this.state
-    const data = service.getData()
-
-    // update connector to get the new account
-    this.setState({submitting: true})
-    this.store.fetchKonnectorInfos(data.slug)
-      .then(konnector => {
-        return this.store
-          .fetchAccounts(data.slug, null)
-          .then(accounts => {
-            konnector.accounts = accounts
-            const currentIdx = accounts.findIndex(a => a._id === accountID)
-            const folderPath = t('konnector default base folder', konnector)
-            this.setState({connector: konnector})
-            return this.runConnection(accounts[currentIdx], folderPath).then(() => {
-              this.setState({
-                connector: konnector,
-                isConnected: konnector.accounts.length !== 0,
-                selectedAccount: currentIdx,
-                submitting: false
-              })
-            }).catch(error => {
-              return this.setState({submitting: false, error: error.message})
-            })
-          })
-      })
-      .catch(error => {
-        this.setState({submitting: false, error: error.message})
-      })
-  }
-
-  runConnection (account, folderPath) {
-    return this.store.connectAccount(this.state.connector, account, folderPath)
-      .then(connection => {
-        this.setState({ submitting: false })
-        if (connection.error) {
-          this.setState({ error: connection.error.message })
-        } else {
-          this.terminate(account)
-        }
       })
   }
 
@@ -175,8 +106,6 @@ export default class IntentService extends Component {
             <CreateAccountService
               konnector={konnector}
               onCancel={() => this.cancel()}
-              onSubmit={auth => this.createAccount(auth, t('konnector default base folder'))}
-              onOAuth={accountType => this.connectAccountOAuth(accountType)}
               onError={error => this.handleError(error)}
               {...this.context}
               />

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -64,16 +64,7 @@ export default class IntentService extends Component {
 
     return this.store.connectAccount(konnector, account, baseFolder)
       .then(connection => this.terminate(connection.account))
-      .catch(error => {
-        this.setState({
-          error: {
-            message: 'intent.service.account.creation.error',
-            reason: error.message
-          }
-        })
-
-        throw error
-      })
+      .catch(error => this.handleError(error))
   }
 
   connectAccountOAuth (accountType) {
@@ -147,6 +138,17 @@ export default class IntentService extends Component {
         : service.terminate(null)
   }
 
+  handleError (error) {
+    this.setState({
+      error: {
+        message: 'intent.service.account.creation.error',
+        reason: error.message
+      }
+    })
+
+    throw error
+  }
+
   render () {
     const { data } = this.props
     const { isFetching, error, konnector } = this.state
@@ -175,6 +177,7 @@ export default class IntentService extends Component {
               onCancel={() => this.cancel()}
               onSubmit={auth => this.createAccount(auth, t('konnector default base folder'))}
               onOAuth={accountType => this.connectAccountOAuth(accountType)}
+              onError={error => this.handleError(error)}
               {...this.context}
               />
           </div>}

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -106,6 +106,7 @@ export default class IntentService extends Component {
             <CreateAccountService
               konnector={konnector}
               onCancel={() => this.cancel()}
+              onSuccess={account => this.terminate(account)}
               onError={error => this.handleError(error)}
               {...this.context}
               />


### PR DESCRIPTION
This refactor regroups all the creation logic into the `AccountConnection` component. It open the way for a better edition modal. Also, we may now manage error and success message directly into AccountConnection.