### PR TITLE
fix: remove bad error message when running a konnector for the second time

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -140,6 +140,7 @@ export default class CollectStore {
         connection.job = job
         if (!connection.konnector || !connection.konnector.slug) {
           console.error(connection.konnector, 'No konnector slug available to register the new konnector trigger')
+          return Promise.reject(new Error('Unexpected error while trying to setup next run of the konnector'))
         }
         return cozy.client.fetchJSON('POST', '/jobs/triggers', {
           data: {

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -145,7 +145,7 @@ export default class CollectStore {
               arguments: '0 0 0 * * *',
               worker: 'konnector',
               worker_arguments: {
-                konnector: connection.konnector.attributes.slug,
+                konnector: connection.konnector.slug,
                 account: connection.account._id,
                 folderToSave: connection.folder._id
               }

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -138,6 +138,9 @@ export default class CollectStore {
       // 8. Creates trigger
       .then(job => {
         connection.job = job
+        if (!connection.konnector || !connection.konnector.slug) {
+          console.error(connection.konnector, 'No konnector slug available to register the new konnector trigger')
+        }
         return cozy.client.fetchJSON('POST', '/jobs/triggers', {
           data: {
             attributes: {


### PR DESCRIPTION
There was a "r.konnector.attributes is undefined" error when running a konnector which was already
installed.

This fetches the konnector slug in a path which exists in any case (according to my tests)