### PR TITLE
fix: sanitize konnector at update to avoid empty categories :ambulance:

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -25,13 +25,20 @@ export default class CollectStore {
   }
 
   updateConnector (connector) {
+    if (!connector) throw new Error('Missing mandatory connector parameter')
     const slug = connector.slug || connector.attributes.slug
-    if (slug) {
-      this.connectors = this.connectors.map(
-        c => c.slug === slug ? Object.assign({}, c, connector) : c
-      )
-    }
-    return this.connectors.find(k => k.slug === slug)
+    if (!slug) throw new Error('Missing mandatory slug property in konnector')
+
+    const current = this.connectors.find(connector => connector.slug === slug)
+    const updatedConnector = Object.assign({}, current, connector)
+
+    this.connectors = this.connectors.map(connector => {
+      return connector === current
+        ? updatedConnector
+          : connector
+    })
+
+    return updatedConnector
   }
 
   getCategories () {

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -24,13 +24,29 @@ export default class CollectStore {
     this.listener = null
   }
 
+  sanitizeKonnector (konnector) {
+    const sanitized = Object.assign({}, konnector)
+
+    // disallow empty category
+    if (sanitized.category === '') {
+      delete sanitized.category
+    }
+
+    return sanitized
+  }
+
+  // Merge source into target
+  mergeKonnectors (source, target) {
+    return Object.assign({}, target, this.sanitizeKonnector(source))
+  }
+
   updateConnector (connector) {
     if (!connector) throw new Error('Missing mandatory connector parameter')
     const slug = connector.slug || connector.attributes.slug
     if (!slug) throw new Error('Missing mandatory slug property in konnector')
 
     const current = this.connectors.find(connector => connector.slug === slug)
-    const updatedConnector = Object.assign({}, current, connector)
+    const updatedConnector = this.mergeKonnectors(connector, current)
 
     this.connectors = this.connectors.map(connector => {
       return connector === current


### PR DESCRIPTION
When updating connector list, installed konnectors were setting an empty category.