### PR TITLE
Add unique names to form inputs to wrong autofills :bug:

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 import statefulForm from '../lib/statefulForm'
 import Field, { PasswordField, DropdownField, CheckboxField } from './Field'
 
-const AccountLoginForm = ({ t, isOAuth, customView, fields, error, dirty, submitting, forceEnabled, deleting, values, submit, onDelete, onCancel }) => {
+const AccountLoginForm = ({ t, isOAuth, customView, fields, error, dirty, submitting, forceEnabled, deleting, values, submit, onDelete, onCancel, connectorSlug }) => {
   const isUpdate = !!values.login || !!values.access_token
   const submitEnabled = dirty || isOAuth || forceEnabled
   return (
@@ -19,9 +19,11 @@ const AccountLoginForm = ({ t, isOAuth, customView, fields, error, dirty, submit
       {Object.keys(fields)
         .filter(name => !fields[name].advanced)
         .map(name => {
+          const inputName = `${name}_${connectorSlug}`
           if (fields[name].type === 'password') {
             return <PasswordField
               label={t(name)}
+              name={inputName}
               placeholder={t('account.connection.login.password.placeholder')}
               invalid={!!error}
               {...fields[name]} />
@@ -38,6 +40,7 @@ const AccountLoginForm = ({ t, isOAuth, customView, fields, error, dirty, submit
 
           return <Field
             label={t(name)}
+            name={inputName}
             readOnly={readOnly}
             invalid={!!error}
             {...fields[name]} />

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -17,7 +17,7 @@ const Field = (props) => {
       )
     )
   } else {
-    const { type, placeholder, value, onChange, onInput, disabled, readOnly } = props
+    const { type, placeholder, value, onChange, onInput, disabled, readOnly, name } = props
     inputs = (
       <input
         type={type}
@@ -26,6 +26,7 @@ const Field = (props) => {
         readonly={readOnly}
         disabled={disabled || readOnly}
         value={value}
+        name={name}
         onChange={onChange}
         onInput={onInput}
       />
@@ -73,7 +74,7 @@ export const PasswordField = translate()(
     }
   }))(
     props => {
-      const { t, placeholder, value, onChange, onInput, toggleVisibility, visible } = props
+      const { t, placeholder, value, onChange, onInput, toggleVisibility, visible, name } = props
       return (
         <FieldWrapper {...props}>
           <button
@@ -93,6 +94,7 @@ export const PasswordField = translate()(
             placeholder={placeholder}
             className={styles['coz-field-input']}
             value={value}
+            name={name}
             onChange={onChange}
             onInput={onInput}
           />

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -231,6 +231,7 @@ class AccountConnection extends Component {
             }
             <AccountLoginForm
               t={t}
+              connectorSlug={connector.slug}
               isOAuth={connector.oauth}
               customView={customView}
               fields={fields}


### PR DESCRIPTION
Use unique names on input should avoid the browser autofill to fill wrong connector forms.