### PR TITLE
feat: display previous error in modification modal

### DIFF
--- a/src/components/ConnectorList.jsx
+++ b/src/components/ConnectorList.jsx
@@ -11,7 +11,7 @@ const ConnectorList = ({ t, connectors, showConnectedBadge = true, showVoting = 
         title={c.name}
         subtitle={t(c.category + ' category')}
         connected={showConnectedBadge && c.accounts.length !== 0}
-        errored={!!c.accounts.isErrored}
+        errored={!!c.accounts.error}
         iconName={c.slug}
         slug={c.slug}
         enableDefaultIcon

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -16,6 +16,8 @@ class AccountConnection extends Component {
     this.state = {
       account: this.props.existingAccount
     }
+
+    if (this.props.error) this.handleError({message: this.props.error})
   }
 
   componentWillReceiveProps ({ existingAccount }) {

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -30,7 +30,7 @@ export default class ConnectorManagement extends Component {
 
     this.state = {
       connector: this.sanitize(connector),
-      isConnected: connector.accounts.length !== 0,
+      isConnected: connector.accounts.length !== 0 && !connector.accounts.error,
       isInstalled: this.isInstalled(connector),
       isWorking: true,
       selectedAccount: 0,
@@ -46,12 +46,14 @@ export default class ConnectorManagement extends Component {
         return this.store
           .fetchAccounts(props.params.connectorSlug, null)
           .then(accounts => {
+            const error = konnector.accounts.error
             konnector.accounts = accounts
             // do not loose previous connector attributes
             this.setState({
               connector: Object.assign(konnector, this.state.connector),
-              isConnected: konnector.accounts.length !== 0,
-              isWorking: false
+              isConnected: konnector.accounts.length !== 0 && !error,
+              isWorking: false,
+              error
             })
           })
       })
@@ -73,7 +75,7 @@ export default class ConnectorManagement extends Component {
 
   render () {
     const { accounts } = this.state.connector
-    const { isConnected, selectedAccount, isWorking } = this.state
+    const { selectedAccount, isWorking } = this.state
     const { t } = this.context
 
     return (
@@ -85,7 +87,7 @@ export default class ConnectorManagement extends Component {
               <div>{t('working')}</div>
             </div>
             : <AccountConnection
-              existingAccount={isConnected ? accounts[selectedAccount] : null}
+              existingAccount={accounts.length ? accounts[selectedAccount] : null}
               onError={(error) => this.handleError(error)}
               onSuccess={(account, messages) => this.handleSuccess(account, messages)}
               onCancel={() => this.gotoParent()}

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -99,9 +99,9 @@ export default class CollectStore {
         let accObject = {}
         accounts.forEach(a => {
           if (!accObject[a.account_type]) accObject[a.account_type] = []
-          if (errorIndex[a._id]) {
-            a.isErrored = true
-            accObject[a.account_type].isErrored = true
+          if (errorIndex[a._id] && errorIndex[a._id].error) {
+            a.error = errorIndex[a._id].error
+            accObject[a.account_type].error = errorIndex[a._id].error
           }
           accObject[a.account_type].push(a)
         })
@@ -188,7 +188,7 @@ export default class CollectStore {
   }
 
   updateKonnectorError (konnector, error = null) {
-    konnector.accounts.isErrored = !!error
+    konnector.accounts.error = error
     this.updateConnector(konnector)
   }
 


### PR DESCRIPTION
CC-2

This displays the error message in the modal if the given connector was errored in the last run
with the previously entered fields, ready to change.