### PR TITLE
feat: set max size for oauth connector intent

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "browser-sync-webpack-plugin": "1.1.3",
     "copy-webpack-plugin": "4.0.0",
     "cozy-bar": "^3.0.0-beta25",
-    "cozy-client-js": "^0.3.3",
+    "cozy-client-js": "^0.3.6",
     "cozy-ui": "3.0.0-beta32",
     "css-loader": "0.25.0",
     "css-mqpacker": "5.0.1",

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -44,6 +44,10 @@ export default class IntentService extends Component {
           konnector: konnector
         })
 
+        this.state.service.setSize({
+          maxWidth: '931px'
+        })
+
         return konnector
       })
       .catch(error => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,9 +1505,9 @@ cozy-bar@^3.0.0-beta25:
   dependencies:
     node-polyglot "^2.2.2"
 
-cozy-client-js@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.3.tgz#23a2e775655eb4f4c077a247c9b3a21d58865b4a"
+cozy-client-js@^0.3.6:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.6.tgz#b47b272ea9ddd5289634f30f70d0be25f3c22df5"
 
 cozy-ui@3.0.0-beta32:
   version "3.0.0-beta32"


### PR DESCRIPTION
This changes the size of the intent modal for intents related to an oauth connector which does not have much content to display.

Do not merge yet since this needs a release of cozy-client-js which is not done yet.