### PR TITLE
fix: password field gets back to invisible when coming to the form

### DIFF
--- a/src/lib/statefulComponent.jsx
+++ b/src/lib/statefulComponent.jsx
@@ -23,8 +23,11 @@ const statefulComponent = (initialState, eventHandlers) => {
     return class StatefulComponent extends Component {
       constructor (props) {
         super(props)
-        this.state = initialState
         this.handlers = eventHandlers(this.setState.bind(this))
+      }
+
+      componentDidMount () {
+        this.state = initialState
       }
 
       render () {


### PR DESCRIPTION
When the user sets the password field to visible and gets back to the list of connectors, he/she
want's it to go back to not visible when he displays that form again or the form for another
connector.