### PR TITLE
fix: remove base64 encoding of source + edf source with ssh

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -152,6 +152,6 @@
     "color":{"hex":"#1C79CD","css":"linear-gradient(135deg, #1C79CD 0%, #06428F 100%)"},
     "dataType":["bill", "contract", "consumption", "profile", "home"],
     "fields":{"email":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
-    "source": "Z2l0Oi8vZ2l0bGFiLmNvenljbG91ZC5jYy9sYWJzL2Nvenkta29ubmVjdG9yLWVkZi5naXQjYnVpbGQ="
+    "source": "git+ssh://gitlab.cozycloud.cc/labs/cozy-konnector-edf.git"
   }
 ]

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -76,9 +76,7 @@ export function install (cozy, konnector, timeout = 120000) {
     if (!konnector[property]) throw new Error(`Missing '${property}' property in konnector`)
   })
 
-  let { slug, source } = konnector
-
-  if (source.substr(0, 3) !== 'git') source = atob(source)
+  const { slug, source } = konnector
 
   return findBySlug(cozy, slug)
     .catch(error => {


### PR DESCRIPTION
Base64 encode is of no use anymore since we now allow private repos.