### PR TITLE
feat: better KonnectorSyncCondition :pencil:

### DIFF
--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -259,7 +259,7 @@ class AccountConnection extends Component {
               messages={[t('account.message.error.global.description', {name: connector.name})]}
             /> }
 
-            { !success && <KonnectorSync
+            { editing && !success && <KonnectorSync
               date={account && account.lastSync}
             /> }
 


### PR DESCRIPTION
I was not understanding how this only `!success` condition was causing `KonnectorSync` display or not. It appears that it is always computed ans displayed, but luckily when the account has no sync date it shows only an empty div. This was causing unecessary props in https://github.com/cozy/cozy-collect/pull/195