### PR TITLE
feat: realtime for connection statuses :sparkles:

### DIFF
--- a/src/components/KonnectorItem.jsx
+++ b/src/components/KonnectorItem.jsx
@@ -1,12 +1,53 @@
+import styles from '../styles/konnectorItem'
+
 import React, { Component } from 'react'
 import { Link, withRouter } from 'react-router'
 import { translate } from 'cozy-ui/react/I18n'
+import { CONNECTION_STATUS } from '../lib/CollectStore'
 
 class KonnectorItem extends Component {
-  render ({ konnector, router }) {
+  constructor (props, context) {
+    super(props, context)
+    this.store = this.context.store
+
+    const { konnector } = this.props
+
+    this.state = {
+      status: this.store.getConnectionStatus(konnector)
+    }
+
+    this.connectionListener = status => {
+      this.setState({
+        status: status
+      })
+    }
+
+    this.store.addConnectionStatusListener(konnector, this.connectionListener)
+  }
+
+  // Pretty tricky here : as preact renders all the KonnectorItem as a list, it
+  // uses already existing components to re-render the list, so this component
+  // may see its konnector change during its lifecycle.
+  // So we have to stop listening to previous konnector status changes.
+  // Otherwise, in CategoryList view, when we change the category as a konnector
+  // is running, we may see other KonnectorItem having their status icon
+  // changed.
+  componentWillReceiveProps (nextProps) {
+    this.store.removeConnectionStatusListener(this.props.konnector, this.connectionListener)
+    this.store.addConnectionStatusListener(nextProps.konnector, this.connectionListener)
+    this.setState({
+      status: this.store.getConnectionStatus(nextProps.konnector)
+    })
+  }
+
+  // Stop listening unmounted KonnectorItems
+  componentWillUnmount () {
+    this.store.removeConnectionStatusListener(this.props.konnector, this.connectionListener)
+  }
+
+  render ({ konnector, jobs, router }) {
+    const { status } = this.state
     const { category, name, slug } = konnector
-    const errored = konnector.accounts.error
-    const connected = !!konnector.accounts.length
     return (
       <Link className='item-wrapper' to={`${router.location.pathname}/${slug}`}>
         <header className='item-header'>
@@ -14,18 +55,29 @@ class KonnectorItem extends Component {
         </header>
         <p className='item-title'>{name}</p>
         {category && <p className='item-subtitle'>{category}</p>}
-        {stateIcon(errored, connected)}
+        {status && stateIcon(status)}
       </Link>
     )
   }
 }
 
-const stateIcon = (errored, connected) => {
-  if (!errored && !connected) return ''
-  return <svg className='item-status-icon'>
-    {errored && <use xlinkHref={require('../assets/sprites/icon-warning.svg')} /> }
-    {(!errored && connected) && <use xlinkHref={require('../assets/sprites/icon-check.svg')} /> }
+const svgIcon = (name) => (
+  <svg className='item-status-icon'>
+    <use xlinkHref={require(`../assets/sprites/icon-${name}.svg`)} /> }
   </svg>
+)
+
+const stateIcon = (status) => {
+  switch (status) {
+    case CONNECTION_STATUS.ERRORED:
+      return svgIcon('warning')
+    case CONNECTION_STATUS.CONNECTED:
+      return svgIcon('check')
+    case CONNECTION_STATUS.RUNNING:
+      return <span className={styles['col-konnector-status-running']} />
+    default:
+      return null
+  }
 }
 
 // Fallback to get the item icon and avoid error if not found

--- a/src/components/KonnectorList.jsx
+++ b/src/components/KonnectorList.jsx
@@ -10,7 +10,6 @@ const KonnectorList = ({ t, connectors, showVoting = false }) => (
     {connectors.map(konnector =>
       <KonnectorItem
         konnector={konnector}
-        connected={konnector.accounts.length !== 0}
         enableDefaultIcon
       />
     )}

--- a/src/components/KonnectorSync.jsx
+++ b/src/components/KonnectorSync.jsx
@@ -6,16 +6,22 @@ import { translate } from 'cozy-ui/react/I18n'
 
 import DescriptionContent from './DescriptionContent'
 
+function getDateLabel ({date, t, f}) {
+  return f(date, t('account.message.synced.date_format'))
+}
+
 export const KonnectorSync = ({ t, f, frequency, date, submitting, onForceConnection }) => {
+  const lastSyncMessage =
+    submitting && t('account.message.synced.syncing') ||
+      date && getDateLabel({date, t, f}) ||
+       ''
   return (
     <div>
       { <DescriptionContent
         title={t('account.message.synced.title')}
         messages={[
           `${t('account.message.synced.cron')} ${t(`account.message.synced.cron_${frequency}`)}.`,
-          date
-          ? t('account.message.synced.last_sync', { date: f(date, t('account.message.synced.date_format')) })
-          : ''
+          t('account.message.synced.last_sync', { date: lastSyncMessage })
         ]}
       /> }
       <div className={styles['account-forceConnection']}>

--- a/src/components/KonnectorSync.jsx
+++ b/src/components/KonnectorSync.jsx
@@ -14,14 +14,14 @@ export const KonnectorSync = ({ t, f, frequency, date, submitting, onForceConnec
   const lastSyncMessage =
     submitting && t('account.message.synced.syncing') ||
       date && getDateLabel({date, t, f}) ||
-       ''
+       null
   return (
     <div>
       { <DescriptionContent
         title={t('account.message.synced.title')}
         messages={[
           `${t('account.message.synced.cron')} ${t(`account.message.synced.cron_${frequency}`)}.`,
-          t('account.message.synced.last_sync', { date: lastSyncMessage })
+          lastSyncMessage ? t('account.message.synced.last_sync', { date: lastSyncMessage }) : ''
         ]}
       /> }
       <div className={styles['account-forceConnection']}>

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -34,7 +34,9 @@ class AccountConnection extends Component {
 
     this.connectionListener = status => {
       this.setState({
-        submitting: this.store.isConnectionStatusRunning(this.props.connector)
+        submitting: this.store.isConnectionStatusRunning(this.props.connector),
+        // dirty hack waiting for better account management in store
+        lastSync: Date.now()
       })
     }
 
@@ -266,7 +268,7 @@ class AccountConnection extends Component {
     const { t, connector, fields, isUnloading } = this.props
     const { submitting, oAuthTerminated, deleting, error, success, account, editing } = this.state
     const hasGlobalError = error && error.message !== ACCOUNT_ERRORS.LOGIN_FAILED
-
+    const lastSync = this.state.lastSync || account && account.lastSync
     return (
       <div className={styles['col-account-connection']}>
         <div className={styles['col-account-connection-header']}>
@@ -284,7 +286,7 @@ class AccountConnection extends Component {
 
             { editing && !success && <KonnectorSync
               frequency={account && account.auth && account.auth.frequency}
-              date={account && account.lastSync}
+              date={lastSync}
               submitting={submitting}
               onForceConnection={() => this.forceConnection()}
             /> }

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -22,19 +22,33 @@ class AccountConnection extends Component {
   constructor (props, context) {
     super(props, context)
     this.store = this.context.store
+    const konnector = props.connector
     this.state = {
       account: this.props.existingAccount,
       editing: !!this.props.existingAccount,
-      success: null
+      success: null,
+      submitting: this.store.isConnectionStatusRunning(konnector)
     }
 
     if (this.props.error) this.handleError({message: this.props.error})
+
+    this.connectionListener = status => {
+      this.setState({
+        submitting: this.store.isConnectionStatusRunning(this.props.connector)
+      })
+    }
+
+    this.store.addConnectionStatusListener(konnector, this.connectionListener)
   }
 
   componentWillReceiveProps ({ existingAccount }) {
     this.setState({
       account: existingAccount
     })
+  }
+
+  componentWillUnmount () {
+    this.store.removeConnectionStatusListener(this.props.connector, this.connectionListener)
   }
 
   connectAccount (auth) {

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -24,6 +24,7 @@ class App extends Component {
         })
       })
       .catch(error => {
+        console.error(error)
         this.setState({
           isFetching: false,
           error

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -16,7 +16,7 @@ class App extends Component {
       isFetching: true
     }
 
-    this.store.fetchAllAccounts()
+    this.store.fetchInitialData()
       .then(() => {
         this.setState({
           categories: this.store.categories,

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -16,7 +16,7 @@ class App extends Component {
       isFetching: true
     }
 
-    this.store.fetchInitialData()
+    this.store.fetchInitialData(props.domain)
       .then(() => {
         this.setState({
           categories: this.store.categories,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -75,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <Router history={history}>
           <Route
             component={(props) =>
-              <App {...props}
+              <App domain={data.cozyDomain} {...props}
               />}
           >
             <Redirect from='/' to='/discovery' />

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -462,6 +462,10 @@ export default class CollectStore {
     return null
   }
 
+  isConnectionStatusRunning (konnector) {
+    return this.getConnectionStatus(konnector) === CONNECTION_STATUS.RUNNING
+  }
+
   // listen for update on connection (will be useful for realtime)
   addConnectionStatusListener (konnector, listener) {
     const slug = konnector.slug || konnector.attributes.slug

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -43,6 +43,8 @@ export default class CollectStore {
     this.useCases = require(`../contexts/${context}/index`).useCases
     this.categories = require('../config/categories')
     this.driveUrl = null
+
+    this.initializeRealtime()
   }
 
   // Populate the store
@@ -52,6 +54,19 @@ export default class CollectStore {
       this.fetchKonnectorResults(),
       this.fetchKonnectorRunningJobs(domain)
     ])
+  }
+
+  initializeRealtime () {
+    jobs.subscribeAll(cozy.client)
+      .then(subscription => {
+        subscription
+          .onCreate(job => this.updateRunningJob(job))
+          .onUpdate(job => this.updateRunningJob(job))
+          .onDelete(job => this.deleteRunningJob(job))
+      })
+      .catch(error => {
+        console.warn && console.warn(`Cannot initialize realtime : ${error.message}`)
+      })
   }
 
   updateKonnectorResult (konnectorResult) {

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -298,16 +298,6 @@ export default class CollectStore {
     return foundIndex
   }
 
-  deleteAccount (konnector, account) {
-    konnector = this.connectors.find(c => c.slug === konnector.slug)
-    konnector.accounts.splice(konnector.accounts.indexOf(account), 1)
-
-    return accounts._delete(cozy.client, account)
-      .then(() => konnectors.unlinkFolder(cozy.client, konnector, account.folderId))
-      .then(() => this.updateConnector(konnector))
-      .then(() => this.updateKonnectorError(konnector))
-  }
-
   deleteAccounts (konnector) {
     konnector = this.connectors.find(c => c.slug === konnector.slug)
     return Promise.all(konnector.accounts.map(account => accounts._delete(cozy.client, account)

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -65,7 +65,17 @@ export default class CollectStore {
           .onDelete(job => this.deleteRunningJob(job))
       })
       .catch(error => {
-        console.warn && console.warn(`Cannot initialize realtime : ${error.message}`)
+        console.warn && console.warn(`Cannot initialize realtime for jobs: ${error.message}`)
+      })
+
+    konnectors.subscribeAllResults(cozy.client)
+      .then(subscription => {
+        subscription
+          .onCreate(result => this.updateKonnectorResult(result))
+          .onUpdate(result => this.updateKonnectorResult(result))
+      })
+      .catch(error => {
+        console.warn && console.warn(`Cannot initialize realtime for jobs: ${error.message}`)
       })
   }
 

--- a/src/lib/jobs.js
+++ b/src/lib/jobs.js
@@ -1,4 +1,6 @@
 /* jobs lib ready to be added to cozy-client-js */
+import * as realtime from './realtime'
+
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 export const JOB_STATE = {
@@ -19,4 +21,8 @@ export function find (cozy, query) {
       return jobs.map(decode)
     })
   )
+}
+
+export function subscribeAll (cozy) {
+  return realtime.subscribeAll(cozy, JOBS_DOCTYPE, decode)
 }

--- a/src/lib/jobs.js
+++ b/src/lib/jobs.js
@@ -1,0 +1,22 @@
+/* jobs lib ready to be added to cozy-client-js */
+export const JOBS_DOCTYPE = 'io.cozy.jobs'
+
+export const JOB_STATE = {
+  RUNNING: 'running'
+}
+
+function decode (job) {
+  return { ...job, ...JSON.parse(window.atob(job.message.Data)) }
+}
+
+export function find (cozy, query) {
+  return cozy.data.defineIndex(JOBS_DOCTYPE, Object.keys(query))
+    // TODO: cache the index
+    .then(index => cozy.data.query(index, {
+      selector: query
+    })
+    .then(jobs => {
+      return jobs.map(decode)
+    })
+  )
+}

--- a/src/lib/jobs.js
+++ b/src/lib/jobs.js
@@ -23,6 +23,10 @@ export function find (cozy, query) {
   )
 }
 
+export function subscribe (cozy, job) {
+  return realtime.subscribe(cozy, JOBS_DOCTYPE, job, decode)
+}
+
 export function subscribeAll (cozy) {
   return realtime.subscribeAll(cozy, JOBS_DOCTYPE, decode)
 }

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -1,4 +1,6 @@
 /* konnector lib ready to be added to cozy-client-js */
+import * as realtime from './realtime'
+
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 export const KONNECTORS_RESULT_DOCTYPE = 'io.cozy.konnectors.result'
 
@@ -91,6 +93,10 @@ export function findAllResults (cozy) {
       if (error.status === 404) return []
       throw error
     })
+}
+
+export function subscribeAllResults (cozy) {
+  return realtime.subscribeAll(cozy, KONNECTORS_RESULT_DOCTYPE)
 }
 
 export function install (cozy, konnector, timeout = 120000) {

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -1,5 +1,6 @@
 /* konnector lib ready to be added to cozy-client-js */
 import * as realtime from './realtime'
+import * as jobs from './jobs'
 
 export const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
 export const KONNECTORS_RESULT_DOCTYPE = 'io.cozy.konnectors.result'
@@ -182,51 +183,39 @@ export function run (cozy, konnector, account, disableSuccessTimeout = false, su
     priority: 10,
     max_exec_count: 1
   })
-  .then(job => waitForJobFinished(cozy, job, account, disableSuccessTimeout, successTimeout))
+  .then(job => waitForJobFinished(cozy, job, disableSuccessTimeout, successTimeout))
 }
 
 // monitor the status of the connector and resolve when the connector is ready
-function waitForJobFinished (cozy, job, account, disableSuccessTimeout, successTimeout) {
+function waitForJobFinished (cozy, job, disableSuccessTimeout, successTimeout) {
   return new Promise((resolve, reject) => {
-    let idTimeout
-    let idInterval
+    jobs.subscribe(cozy, job)
+      .then(subscription => {
+        let idTimeout
 
-    if (!disableSuccessTimeout) {
-      idTimeout = setTimeout(() => {
-        clearInterval(idInterval)
-        resolve(job)
-      }, successTimeout)
-    }
+        if (!disableSuccessTimeout) {
+          idTimeout = setTimeout(() => {
+            resolve(job)
+            subscription.unsubscribe()
+          }, successTimeout)
+        }
 
-    idInterval = setInterval(() => {
-      cozy.fetchJSON('GET', `/jobs/${job._id}`)
-        .then(job => {
-          if (job.attributes.state === JOB_STATE.ERRORED) {
-            if (idTimeout) {
-              clearTimeout(idTimeout)
-            }
-
-            clearInterval(idInterval)
-            reject(new Error(job.attributes.error))
+        subscription.onUpdate(job => {
+          if (job.state === JOB_STATE.ERRORED) {
+            clearTimeout(idTimeout)
+            subscription.unsubscribe()
+            reject(new Error(job.error))
           }
 
-          if (job.attributes.state === JOB_STATE.READY) {
-            if (idTimeout) {
-              clearTimeout(idTimeout)
-            }
-
-            clearInterval(idInterval)
+          if (job.state === JOB_STATE.DONE) {
+            clearTimeout(idTimeout)
+            subscription.unsubscribe()
             resolve(job)
           }
         })
-        .catch(error => {
-          if (idTimeout) {
-            clearTimeout(idTimeout)
-          }
-
-          clearInterval(idInterval)
-          reject(error)
-        })
-    }, 1000)
+      })
+      .catch(error => {
+        reject(error)
+      })
   })
 }

--- a/src/lib/realtime.js
+++ b/src/lib/realtime.js
@@ -1,0 +1,169 @@
+/* global WebSocket */
+
+// Custom object wrapping logic to websocket and exposing a subscription
+// interface
+let cozySocket
+
+// Important, must match the spec,
+// see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
+const WEBSOCKET_STATE = {
+  OPEN: 1
+}
+
+// Send a subscribe message for the given doctype trough the given websocket, but
+// only if it is in a ready state. If not, retry a few milliseconds later.
+function subscribeWhenReady (doctype, socket) {
+  if (socket.readyState === WEBSOCKET_STATE.OPEN) {
+    try {
+      socket.send(JSON.stringify({
+        method: 'SUBSCRIBE',
+        payload: {
+          type: doctype
+        }
+      }))
+    } catch (error) {
+      console.warn && console.warn(`Cannot subscribe to doctype ${doctype}: ${error.message}`)
+      throw error
+    }
+  } else {
+    setTimeout(() => {
+      subscribeWhenReady(doctype, socket)
+    }, 10)
+  }
+}
+
+function getWebsocketProtocol () {
+  return window.location.protocol === 'https' ? 'wss' : 'ws'
+}
+
+function getCozySocket (cozy) {
+  return new Promise((resolve, reject) => {
+    if (cozySocket) return resolve(cozySocket)
+
+    const listeners = {}
+
+    cozySocket = {
+      subscribe: (doctype, event, listener) => {
+        if (typeof listener !== 'function') throw new Error('Realtime event listener must be a function')
+
+        if (!listeners[doctype]) {
+          listeners[doctype] = {}
+          subscribeWhenReady(doctype, socket)
+        }
+
+        listeners[doctype][event] = (listeners[doctype][event] || []).concat([listener])
+      },
+      unsubscribe: (doctype, event, listener) => {
+        if (listeners[doctype] && listeners[doctype][event] && listeners[doctype][event].includes(listener)) {
+          listeners[doctype][event] = listeners[doctype][event].filter(l => l !== listener)
+        }
+      }
+    }
+
+    let socket
+
+    try {
+      const protocol = getWebsocketProtocol()
+      socket = new WebSocket(`${protocol}:${cozy._url}/realtime/`, 'io.cozy.websocket')
+    } catch (error) {
+      return reject(error)
+    }
+
+    socket.onopen = (event) => {
+      try {
+        socket.send(JSON.stringify({
+          method: 'AUTH',
+          payload: cozy._token.token
+        }))
+      } catch (error) {
+        return reject(error)
+      }
+
+      resolve(cozySocket)
+    }
+
+    socket.onmessage = (event) => {
+      const data = JSON.parse(event.data)
+      const eventType = data.event.toLowerCase()
+      const payload = data.payload
+
+      if (eventType === 'error') {
+        const realtimeError = new Error(payload.title)
+        const errorFields = ['status', 'code', 'source']
+        errorFields.forEach(property => {
+          realtimeError[property] = payload[property]
+        })
+        throw realtimeError
+      }
+
+      if (listeners[payload.type] && listeners[payload.type][eventType]) {
+        listeners[payload.type][eventType].forEach(listener => {
+          listener(payload.doc)
+        })
+      }
+    }
+  })
+}
+
+// Returns the Promise of a subscription to a given doctype and document
+export function subscribe (cozy, doctype, doc, parse = doc => doc) {
+  return subscribeAll(cozy, doctype, parse)
+    .then(subscription => {
+      // We will call the listener only for the given document, so let's curry it
+      const docListenerCurried = (listener) => {
+        return syncedDoc => {
+          if (syncedDoc._id === doc._id) {
+            listener(syncedDoc)
+          }
+        }
+      }
+
+      return {
+        onCreate: (listener) => subscription.onCreate(docListenerCurried(listener)),
+        onUpdate: (listener) => subscription.onUpdate(docListenerCurried(listener)),
+        onDelete: (listener) => subscription.onDelete(docListenerCurried(listener)),
+        unsubscribe: () => subscription.unsubscribe()
+      }
+    })
+}
+
+// Returns the Promise of a subscription to a given doctype (all documents)
+export function subscribeAll (cozy, doctype, parse = doc => doc) {
+  return getCozySocket(cozy)
+    .then(cozySocket => {
+      // Some document need to have specific parsing, for example, decoding
+      // base64 encoded properties
+      const parseCurried = (listener) => {
+        return doc => {
+          listener(parse(doc))
+        }
+      }
+
+      let createListener, updateListener, deleteListener
+
+      const subscription = {
+        onCreate: (listener) => {
+          createListener = parseCurried(listener)
+          cozySocket.subscribe(doctype, 'created', createListener)
+          return subscription
+        },
+        onUpdate: (listener) => {
+          updateListener = parseCurried(listener)
+          cozySocket.subscribe(doctype, 'updated', updateListener)
+          return subscription
+        },
+        onDelete: (listener) => {
+          deleteListener = parseCurried(listener)
+          cozySocket.subscribe(doctype, 'deleted', deleteListener)
+          return subscription
+        },
+        unsubscribe: () => {
+          cozySocket.unsubscribe(doctype, 'created', createListener)
+          cozySocket.unsubscribe(doctype, 'updated', updateListener)
+          cozySocket.unsubscribe(doctype, 'deleted', deleteListener)
+        }
+      }
+
+      return subscription
+    })
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -87,6 +87,7 @@
         "cron_week": "once a week",
         "cron_month": "once a month",
         "cron_undefined": "manually",
+        "syncing": "running ...",
         "last_sync": "Last synchronization: %{date}",
         "date_format": "MMMM Mo[,] YYYY [at] HH[:]mm",
         "bill": "Find your datas in the Drive app at this location:"

--- a/src/styles/konnectorItem.styl
+++ b/src/styles/konnectorItem.styl
@@ -1,0 +1,11 @@
+@import 'cozy-ui'
+
+:local // @stylint ignore
+
+    .col-konnector-status-running
+        position absolute
+        width    24px
+        height   24px
+        bottom   1em
+        right    1em
+        @extend $icon-spinner-blue


### PR DESCRIPTION
In this PR `CollectStore` starts to behave like a redux state, and now contains a few `Map` of synced objects.

# Realtime
## Requirements
You need to have a redis instance running locally
```
docker run -p 6379:6379 redis
```
And store jobs in redis, so add this configuration to your `cozy.yaml``
```yaml
jobs:
    workers: 1
    url: redis://localhost:6379/5
```

## Now rely only on konnectorResults
Until now we were guessing connection statuses thanks to hackish condition on konnector accounts. From now, we will be only relying on konnectorResult documents.
```js
this.konnectorResults = new Map()
```
## Rely also on running jobs to know the running status of konnectors
A list of running jobs is added in store, fetch at startup and maintained up to date thanks to realtime.
```js
this.runningJobs = new Map()
```
Those two previous improvements are a good example of what should be the next evolutions of `CollectStore`, and looks like a lot like the way redux manages its state. Using those patterns will facilitate the transition and refactoring IMHO. The next internal properties to be improved should be `this.konnectors` and `this.accounts`.

## Listenning to konnector connection status updates
`CollectStore` now offers to subscribe to konnectors statuses update, via the method `CollectStore.addConnectionStatusListener(konnector, listener)`.

## Selector
I tried to use the most as possible some kind of selectors directly implemented into the store. It starts to prepare migration to redux. My goal is to avoid completely hackish condition in code like `if (konnector.account.length)` and replace them by something like `this.store.konnectorHasAccounts(konnector)`.

## Realtime
I made some choices about the interface exposed by the realtime library :
 * Internally, the library deals with a `cozySocket`, a wrapping object for a real WebSocket object, exposing some methods like `subscribe(doctype, event, listener)` and unsubscribe(doctype, event, listener). I assume that in this lib developers know what they're doing, which events may be captured on which doctype.
 * Externally, the interface differs a little, it exposes a `subscribe(doctype, listener)` method which returns a Promise for a `subscription` object. This object offers three methods : `onCreate(listener)`, `onUpdate(listener)`, `onDelete(listener)`. Maybe we will need a `onCreateOrUpdate(listener)` soon. The idea is to not let developers, dealing with explicit event names at this stage, and offer them only three methods to register their listeners.
 * Finally, other libs are encapsulating realtime to manage `doctype` by theirselves. That the case for the `jobs` library, which just exposes a `subscribe(listener)` method, returning the Promise for the same `subscription` object than above.
### Example
```js
    jobs.subscribeAll(cozy.client)
      .then(subscription => {
        subscription
          .onCreate(job => this.updateRunningJob(job))
          .onUpdate(job => this.updateRunningJob(job))
          .onDelete(job => this.deleteRunningJob(job))
      })
      .catch(error => {
        console.warn && console.warn(`Cannot initialize realtime for jobs: ${error.message}`)
      })
```
I will be glad to have some feedback about this implementation. I think it could be useful to have some high level implementation, but I understand that it is pretty unusual.