### PR TITLE
fix: better KonnectorFolder condition :ambulance:

### DIFF
--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -263,7 +263,7 @@ class AccountConnection extends Component {
               date={account && account.lastSync}
             /> }
 
-            {!success && account && account.auth && <KonnectorFolder
+            { editing && !success && <KonnectorFolder
               connector={connector}
               account={account}
               driveUrl={this.store.driveUrl}


### PR DESCRIPTION
`KonnectorFolder` was displayed randomly when connecting a new account.