### PR TITLE
fix: add folderPath handling for OAuth connectors

### DIFF
--- a/src/components/KonnectorFolder.jsx
+++ b/src/components/KonnectorFolder.jsx
@@ -11,7 +11,7 @@ export const KonnectorFolder = ({ t, account, driveUrl, connector }) => {
         title={t('account.folder.title')}
       >
         <p>
-          <span className={styles['col-account-folder-highlighted-data']}>{account.auth.folderPath}</span>
+          <span className={styles['col-account-folder-highlighted-data']}>{account.auth ? account.auth.folderPath : ''}</span>
           {driveUrl
             ? <a className={styles['col-account-folder-link']} href={`${driveUrl}${account.folderId}`}>{t('account.folder.link')}</a>
             : ''

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -59,7 +59,7 @@ class AccountConnection extends Component {
       .catch(error => this.handleError(error))
   }
 
-  connectAccountOAuth (accountType) {
+  connectAccountOAuth (accountType, values) {
     this.setState({
       submitting: true,
       oAuthTerminated: false
@@ -70,14 +70,14 @@ class AccountConnection extends Component {
     const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=openid+profile+offline_access&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
     return waitForClosedPopup(newTab, `${accountType}_oauth`)
     .then(accountID => {
-      return this.terminateOAuth(accountID)
+      return this.terminateOAuth(accountID, values.folderPath)
     })
     .catch(error => {
       this.setState({submitting: false, error: error.message})
     })
   }
 
-  terminateOAuth (accountID) {
+  terminateOAuth (accountID, folderPath) {
     const { t } = this.context
     const { slug } = this.props.connector
 
@@ -95,7 +95,7 @@ class AccountConnection extends Component {
             const account = accounts[currentIdx]
             this.setState({account: account})
             account.folderPath = account.folderPath || t('account.config.default_folder', konnector)
-            return this.runConnection(accounts[currentIdx], account.folderPath)
+            return this.runConnection(accounts[currentIdx], folderPath)
               .then(connection => {
                 this.setState({
                   connector: konnector,
@@ -217,7 +217,7 @@ class AccountConnection extends Component {
 
   submit (values) {
     return this.props.connector && this.props.connector.oauth
-         ? this.connectAccountOAuth(this.props.connector.slug)
+         ? this.connectAccountOAuth(this.props.connector.slug, values)
          : this.connectAccount(values)
   }
 


### PR DESCRIPTION
And with this, the display of the MAIF connector form does not break the page