### PR TITLE
fix: typo in websocket protocol detection :ambulance:

### DIFF
--- a/src/lib/realtime.js
+++ b/src/lib/realtime.js
@@ -33,7 +33,7 @@ function subscribeWhenReady (doctype, socket) {
 }
 
 function getWebsocketProtocol () {
-  return window.location.protocol === 'https' ? 'wss' : 'ws'
+  return window.location.protocol === 'http:' ? 'ws' : 'wss'
 }
 
 function getCozySocket (cozy) {


### PR DESCRIPTION
Add missing `:`.
Look for http instead of https to detect bugs locally instead of directly in staging/production.