### PR TITLE
WIP : Put Orange connectors back. Quick and Dirty fix for OAuth scopes.

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -186,5 +186,81 @@
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
     "source": "git://github.com/cozy/cozy-konnector-uber.git#build"
+  },
+  {
+    "accounts":[],
+    "slug":"orange",
+    "name":"Orange",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"telecom",
+    "color":{"hex":"#FF6122","css":"#FF6122"},
+    "dataType":["bill"],
+    "fields":{
+      "login": {
+        "type":"text"
+      },
+      "password": {
+        "type":"password"
+       },
+       "folderPath": {
+          "type":"folder",
+          "advanced":true
+        }
+    },
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "source": "git://github.com/cozy/cozy-konnector-orange.git#build"
+  },
+  {
+    "accounts":[],
+    "oauth": true,
+    "slug":"orangemobile",
+    "name":"Orange Mobile",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"telecom",
+    "color":{
+      "hex":"#FF6122",
+      "css":"#FF6122"
+    },
+    "dataType":["geopoint", "phonecommunicationlog"],
+    "fields":{
+        "access_token":{"type":"hidden"},
+        "folderPath":{"type":"folder","advanced":true},
+        "agreement": {"type": "checkbox", "hasDescription": true}},
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "hasDescriptions": {
+      "service": true,
+      "connector": true
+    },
+    "source": "git://gitlab.cozycloud.cc/gjacquart/cozy-konnector-orangemobile.git#build"
+  },
+  {
+    "accounts":[],
+    "oauth": true,
+    "slug":"orangelivebox",
+    "name":"Orange Livebox",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"isp",
+    "color":{"hex": "#FF6122", "css": "#FF6122"},
+    "dataType":["videostream"],
+    "fields": {
+      "access_token": {
+        "type":"hidden"
+      },
+      "folderPath":{
+        "type": "folder",
+        "advanced":true
+      }
+    },
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "hasDescriptions": {
+      "service": true
+    },
+    "source": "git://github.com/cozy/cozy-konnector-orangevod.git#build"
   }
 ]

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -81,9 +81,16 @@ class AccountConnection extends Component {
       oAuthTerminated: false
     })
 
+    // TODO: Quick and Dirty account type <=> scope link.
+    const scopesBySlug = {
+      orangemobile: 'M',
+      orangelivebox: 'I',
+      maif: 'openid+profile+offline_access'
+    }
+
     const cozyUrl =
       `${window.location.protocol}//${document.querySelector('[role=application]').dataset.cozyDomain}`
-    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=openid+profile+offline_access&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
+    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=${scopesBySlug[accountType]}&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
     return waitForClosedPopup(newTab, `${accountType}_oauth`)
     .then(accountID => {
       return this.terminateOAuth(accountID, values.folderPath)


### PR DESCRIPTION
Put back Orange connectors.
Quick and dirty fix for scopes. I don't find any mechanism in cozy-collect to use what the connector declares in manifest on this purpose, so there is a working solution.

WIP: 
* Wait for Orange API be ready.
* The checkbox 'agreement' in orangemobile doesn't send any data to the konnector, user won't be able to get their Geopoint data without this functionality.

ping @poupotte , @doubleface 