### PR TITLE
feat: enable click-everywhere on every device

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "date-fns": "^1.28.5",
     "expose-loader": "^0.7.3",
     "intro.js": "2.5.0",
-    "ismobilejs": "^0.4.1",
     "node-polyglot": "2.0.0",
     "piwik-react-router": "^0.8.2",
     "preact": "^8.1.0",

--- a/src/lib/tutorial.js
+++ b/src/lib/tutorial.js
@@ -1,5 +1,4 @@
 import { introJs } from 'intro.js'
-import isMobile from 'ismobilejs'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
 require('../../node_modules/intro.js/minified/introjs.min.css')
 
@@ -82,16 +81,14 @@ export function display (t) {
     window.location.hash = '#/discovery'
   })
   .start()
-  if (isMobile.phone) {
-    const clickZone = '.introjs-disableInteraction, .introjs-overlay, .introjs-tooltiptext, .introjs-tooltipbuttons'
-    const clickAction = (e) => {
-      if (e.srcElement.tagName !== 'A') {
-        e.stopPropagation()
-        tutorial.nextStep()
-      }
+  const clickZone = '.introjs-disableInteraction, .introjs-overlay, .introjs-tooltiptext, .introjs-tooltipbuttons'
+  const clickAction = (e) => {
+    if (e.srcElement.tagName !== 'A') {
+      e.stopPropagation()
+      tutorial.nextStep()
     }
-    for (const elem of document.querySelectorAll(clickZone)) {
-      elem.onclick = clickAction
-    }
+  }
+  for (const elem of document.querySelectorAll(clickZone)) {
+    elem.onclick = clickAction
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,10 +3096,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
-ismobilejs@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/ismobilejs/-/ismobilejs-0.4.1.tgz#1a5f126c70fed39c93da380fa62cbae5723e7dc2"
-
 isobject@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"


### PR DESCRIPTION
Makes it possible to click everywhere on the overlay to advance the tutorial, regardless of the device, as requested [here](https://trello.com/c/GJUsCLjm/455-glob-%F0%9F%90%9B-toute-la-zone-nest-pas-cliquable-dans-le-wizard-de-collect).