### PR TITLE
fix: get error from Konnector Result when no reatime for jobs :ambulance:

### DIFF
--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -36,6 +36,7 @@ class AccountConnection extends Component {
     this.connectionListener = status => {
       this.setState({
         submitting: this.store.isConnectionStatusRunning(this.props.connector),
+        error: this.store.getConnectionError(this.props.connector),
         // dirty hack waiting for better account management in store
         lastSync: Date.now()
       })


### PR DESCRIPTION
When real time fails for jobs for a reason or another, we need to get the error message from the KonnectorResult.