### PR TITLE
Oauth connexion fixes

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -55,6 +55,8 @@ const AccountLoginForm = ({ t, isOAuth, oAuthTerminated, fields, error, dirty, s
                 <DropdownField label={t(`account.form.label.${name}`)} {...fields[name]} />
               </div>
             case 'checkbox':
+              // force boolean type here since it's just a checkbox
+              fields[name].value = !!fields[name].value
               return <div>
                 {description}
                 <CheckboxField label={t(`account.form.label.${name}`)} {...fields[name]} />

--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -213,5 +213,82 @@
     "fields":{"login":{"type":"text"},"password":{"type":"password"},"folderPath":{"type":"folder","advanced":true}},
     "dataType":["bill"],
     "source": "git://github.com/cozy/cozy-konnector-uber.git#build"
+  },
+  {
+    "accounts":[],
+    "slug":"orange",
+    "name":"Orange",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"telecom",
+    "color":{"hex":"#FF6122","css":"#FF6122"},
+    "dataType":["bill"],
+    "fields":{
+      "login": {
+        "type":"text"
+      },
+      "password": {
+        "type":"password"
+       },
+       "folderPath": {
+          "type":"folder",
+          "advanced":true
+        }
+    },
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "source": "git://github.com/cozy/cozy-konnector-orange.git#build"
+  },
+  {
+    "accounts":[],
+    "oauth": true,
+    "slug":"orangemobile",
+    "name":"Orange Mobile",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"telecom",
+    "color":{
+      "hex":"#FF6122",
+      "css":"#FF6122"
+    },
+    "dataType":["geopoint", "phonecommunicationlog"],
+    "fields":{
+        "access_token":{"type":"hidden"},
+        "folderPath":{"type":"folder","advanced":true},
+        "agreement": {"type": "checkbox", "hasDescription": true}
+    },
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "hasDescriptions": {
+      "service": true,
+      "connector": true
+    },
+    "source": "git://gitlab.cozycloud.cc/gjacquart/cozy-konnector-orangemobile.git#build"
+  },
+  {
+    "accounts":[],
+    "oauth": true,
+    "slug":"orangelivebox",
+    "name":"Orange Livebox",
+    "vendorLink":"https://www.orange.fr/",
+    "category":"isp",
+    "color":{"hex": "#FF6122", "css": "#FF6122"},
+    "dataType":["videostream"],
+    "fields": {
+      "access_token": {
+        "type":"hidden"
+      },
+      "folderPath":{
+        "type": "folder",
+        "advanced":true
+      }
+    },
+    "additionnalSuccessMessage": {
+      "message": "connector.orange.message.delay"
+    },
+    "hasDescriptions": {
+      "service": true
+    },
+    "source": "git://github.com/cozy/cozy-konnector-orangevod.git#build"
   }
 ]

--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -102,7 +102,8 @@
     "color":{"hex":"#007858","css":"#007858"},
     "fields":{"access_token":{"type":"hidden"}},
     "dataType":["profile", "contract", "home", "family", "sinister"],
-    "source": "git://github.com/cozy/cozy-konnector-maif.git#build"
+    "source": "git://github.com/cozy/cozy-konnector-maif.git#build",
+    "oauth_scope": "openid+profile+offline_access"
   },
   {
     "accounts":[],
@@ -263,7 +264,8 @@
       "service": true,
       "connector": true
     },
-    "source": "git://gitlab.cozycloud.cc/gjacquart/cozy-konnector-orangemobile.git#build"
+    "source": "git://gitlab.cozycloud.cc/gjacquart/cozy-konnector-orangemobile.git#build",
+    "oauth_scope": "M"
   },
   {
     "accounts":[],
@@ -289,6 +291,7 @@
     "hasDescriptions": {
       "service": true
     },
-    "source": "git://github.com/cozy/cozy-konnector-orangevod.git#build"
+    "source": "git://github.com/cozy/cozy-konnector-orangevod.git#build",
+    "oauth_scope": "I"
   }
 ]

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -100,9 +100,16 @@ class AccountConnection extends Component {
       oAuthTerminated: false
     })
 
+    // TODO: Quick and Dirty account type <=> scope link.
+    const scopesBySlug = {
+      orangemobile: 'M',
+      orangelivebox: 'I',
+      maif: 'openid+profile+offline_access'
+    }
+
     const cozyUrl =
       `${window.location.protocol}//${document.querySelector('[role=application]').dataset.cozyDomain}`
-    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=openid+profile+offline_access&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
+    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=${scopesBySlug[accountType]}&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
     return waitForClosedPopup(newTab, `${accountType}_oauth`)
     .then(accountID => {
       return this.terminateOAuth(accountID, values)

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -133,9 +133,11 @@ class AccountConnection extends Component {
           .then(accounts => {
             konnector.accounts = accounts
             const currentIdx = accounts.findIndex(a => a._id === accountID)
-            const account = Object.assign({}, accounts[currentIdx], accountValues)
+            // get all properties except folderPath in newValues
+            const {folderPath, ...newValues} = accountValues
+            const account = Object.assign({}, accounts[currentIdx], {auth: newValues})
             this.setState({account: account})
-            return this.runConnection(accounts[currentIdx], accountValues.folderPath)
+            return this.runConnection(account, folderPath)
               .then(connection => {
                 this.setState({
                   connector: konnector,

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -105,14 +105,14 @@ class AccountConnection extends Component {
     const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=openid+profile+offline_access&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
     return waitForClosedPopup(newTab, `${accountType}_oauth`)
     .then(accountID => {
-      return this.terminateOAuth(accountID, values.folderPath)
+      return this.terminateOAuth(accountID, values)
     })
     .catch(error => {
       this.setState({submitting: false, error: error.message})
     })
   }
 
-  terminateOAuth (accountID, folderPath) {
+  terminateOAuth (accountID, accountValues) {
     const { slug } = this.props.connector
 
     this.setState({
@@ -126,9 +126,9 @@ class AccountConnection extends Component {
           .then(accounts => {
             konnector.accounts = accounts
             const currentIdx = accounts.findIndex(a => a._id === accountID)
-            const account = accounts[currentIdx]
+            const account = Object.assign({}, accounts[currentIdx], accountValues)
             this.setState({account: account})
-            return this.runConnection(accounts[currentIdx], folderPath)
+            return this.runConnection(accounts[currentIdx], accountValues.folderPath)
               .then(connection => {
                 this.setState({
                   connector: konnector,

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -94,22 +94,15 @@ class AccountConnection extends Component {
       .catch(error => this.handleError(error))
   }
 
-  connectAccountOAuth (accountType, values) {
+  connectAccountOAuth (accountType, values, scope) {
     this.setState({
       submitting: true,
       oAuthTerminated: false
     })
 
-    // TODO: Quick and Dirty account type <=> scope link.
-    const scopesBySlug = {
-      orangemobile: 'M',
-      orangelivebox: 'I',
-      maif: 'openid+profile+offline_access'
-    }
-
     const cozyUrl =
       `${window.location.protocol}//${document.querySelector('[role=application]').dataset.cozyDomain}`
-    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=${scopesBySlug[accountType]}&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
+    const newTab = popupCenter(`${cozyUrl}/accounts/${accountType}/start?scope=${scope}&state=xxx&nonce=${Date.now()}`, `${accountType}_oauth`, 800, 800)
     return waitForClosedPopup(newTab, `${accountType}_oauth`)
     .then(accountID => {
       return this.terminateOAuth(accountID, values)
@@ -265,7 +258,7 @@ class AccountConnection extends Component {
     })
 
     return this.props.connector && this.props.connector.oauth
-         ? this.connectAccountOAuth(this.props.connector.slug, values)
+         ? this.connectAccountOAuth(this.props.connector.slug, values, this.props.connector.oauth_scope)
          : this.connectAccount(values)
   }
 

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -300,8 +300,7 @@ export default class CollectStore {
         connection.folderID = folderID
         if (isOAuth) {
           const newAttributes = {
-            folderId: folderID,
-            status: 'PENDING'
+            folderId: folderID
           }
           return accounts.update(cozy.client, account, Object.assign({}, account, newAttributes))
         } else {

--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -13,7 +13,6 @@ export function create (cozy, konnector, auth, folderID, name = '') {
   return cozy.data.create(ACCOUNTS_DOCTYPE, {
     name: name,
     account_type: konnector.slug,
-    status: 'PENDING',
     auth: auth,
     folderId: folderID
   })

--- a/test/lib/accounts.spec.js
+++ b/test/lib/accounts.spec.js
@@ -41,8 +41,7 @@ const accountMock = {
     password: 'khf79NEBDX'
   },
   folderId: '4d1039c9a419779f70d1dee5f200992a',
-  name: '',
-  status: 'PENDING'
+  name: ''
 }
 
 const accountMock2 = {
@@ -55,8 +54,7 @@ const accountMock2 = {
     password: 'khf79dzeNEBDX'
   },
   folderId: '4d1039c9a419779f70d1dee5f2009b8f',
-  name: '',
-  status: 'PENDING'
+  name: ''
 }
 
 const indexMock = {
@@ -95,7 +93,6 @@ describe('accounts library', () => {
         expect(cozyMock.data.create.mock.calls[0][1]).toEqual({
           name: 'mock',
           account_type: konnectorMock.slug,
-          status: 'PENDING',
           auth: accountMock.auth,
           folderId: folderMock._id
         })
@@ -110,7 +107,6 @@ describe('accounts library', () => {
         expect(cozyMock.data.create.mock.calls[0][1]).toEqual({
           name: '',
           account_type: konnectorMock.slug,
-          status: 'PENDING',
           auth: accountMock.auth,
           folderId: folderMock._id
         })


### PR DESCRIPTION
* Handle account fields in case of oauth connector (need for a checkbox for Orange Mobile)
* Remove unused 'PENDING' status in account doc
* Cherry pick the commit from #223 to get back Orange konnectors (Thanks @jacquarg 👍 )
* Handle correctly OAuth scope directly from the konnector manifest