### PR TITLE
feat: load queued jobs as unfinished jobs at startup :ambulance:

### DIFF
--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -55,7 +55,7 @@ export default class CollectStore {
       this.fetchAllAccounts(),
       this.fetchInstalledKonnectors(),
       this.fetchKonnectorResults(),
-      this.fetchKonnectorRunningJobs(domain)
+      this.fetchKonnectorUnfinishedJobs(domain)
     ])
   }
 
@@ -261,9 +261,13 @@ export default class CollectStore {
       })
   }
 
-  fetchKonnectorRunningJobs (domain) {
+  fetchKonnectorUnfinishedJobs (domain) {
     return jobs.find(cozy.client, {
-      state: jobs.JOB_STATE.RUNNING,
+      $or: [{
+        state: jobs.JOB_STATE.RUNNING
+      }, {
+        state: jobs.JOB_STATE.QUEUED
+      }],
       worker: 'konnector',
       domain: domain
     })

--- a/src/lib/jobs.js
+++ b/src/lib/jobs.js
@@ -4,6 +4,7 @@ import * as realtime from './realtime'
 export const JOBS_DOCTYPE = 'io.cozy.jobs'
 
 export const JOB_STATE = {
+  QUEUED: 'queued',
   DONE: 'done',
   ERRORED: 'errored',
   RUNNING: 'running'
@@ -18,7 +19,7 @@ export function findById (cozy, id) {
 }
 
 export function find (cozy, query) {
-  return cozy.data.defineIndex(JOBS_DOCTYPE, Object.keys(query))
+  return cozy.data.defineIndex(JOBS_DOCTYPE, ['worker', 'domain'])
     // TODO: cache the index
     .then(index => cozy.data.query(index, {
       selector: query


### PR DESCRIPTION
Queued jobs were not loaded at startup, so konnector statuses in collect was inapropriate.