### PR TITLE
feat: add redux and redux-cozy-client :sparkles:

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,5 +9,5 @@
     }],
     "react"
   ],
-  "plugins": ["transform-object-rest-spread"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
 }

--- a/config/webpack.config.cozy-collect.js
+++ b/config/webpack.config.cozy-collect.js
@@ -3,10 +3,13 @@
 const path = require('path')
 const { ProvidePlugin } = require('webpack')
 
+const SRC_DIR = path.resolve(__dirname, '../src')
+
 module.exports = {
   resolve: {
     alias: {
-      config: path.resolve(__dirname, '../src/config')
+      config: path.resolve(SRC_DIR, './config'),
+      'redux-cozy-client': path.resolve(SRC_DIR, './lib/redux-cozy-client')
     }
   },
   plugins: [

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -14,6 +14,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       __SERVER__: JSON.stringify('http://app.cozy.tools'),
+      __DEVTOOLS__: true,
       __STACK_ASSETS__: false,
       __PIWIK_SITEID__: 8,
       __PIWIK_DIMENSION_ID_APP__: 1,

--- a/package.json
+++ b/package.json
@@ -65,12 +65,14 @@
     "react-router": "3.0.3",
     "redux": "^3.7.2",
     "redux-logger": "^3.0.6",
+    "redux-thunk": "^2.2.0",
     "timeago-react": "^1.0.7"
   },
   "devDependencies": {
     "autoprefixer": "6.5.1",
     "babel-core": "6.18.0",
     "babel-loader": "6.2.5",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-plugin-transform-runtime": "6.15.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prewatch:browser": "npm run clean:browser",
     "prewatch:mobile": "npm run clean:mobile",
     "lint": "npm-run-all --parallel 'lint:*'",
-    "lint:js": "standard 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js' 'mobile/src/**/*.js' 'mobile/src/**/*.jsx' 'mobile/test/**/*.js'",
+    "lint:js": "standard --parser babel-eslint 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js'",
     "lint:styles": "stylint src/styles --config ./.stylintrc",
     "stack:docker": "docker run --rm -it -p 8080:8080 -v \"$(pwd)/build\":/data/cozy-app/collect cozy/cozy-app-dev",
     "test": "node_modules/.bin/jest --verbose --coverage",
@@ -71,6 +71,7 @@
   "devDependencies": {
     "autoprefixer": "6.5.1",
     "babel-core": "6.18.0",
+    "babel-eslint": "^7.2.3",
     "babel-loader": "6.2.5",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "react-redux": "^5.0.6",
     "react-router": "3.0.3",
     "redux": "^3.7.2",
+    "redux-logger": "^3.0.6",
     "timeago-react": "^1.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,9 @@
     "preact": "^8.1.0",
     "preact-compat": "^3.16.0",
     "react-markdown": "^2.5.0",
+    "react-redux": "^5.0.6",
     "react-router": "3.0.3",
+    "redux": "^3.7.2",
     "timeago-react": "^1.0.7"
   },
   "devDependencies": {

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -8,6 +8,7 @@ import Loading from '../components/Loading'
 import Failure from '../components/Failure'
 
 import { initializeRegistry } from '../ducks/registry'
+import { fetchKonnectors } from '../ducks/konnectors'
 
 class App extends Component {
   constructor (props, context) {
@@ -69,6 +70,8 @@ const mapActionsToProps = (dispatch) => ({
   initializeRegistry: (konnectors) => dispatch(initializeRegistry(konnectors))
 })
 
-const mapDocumentsToProps = (ownProps) => ({})
+const mapDocumentsToProps = (ownProps) => ({
+  konnectors: fetchKonnectors()
+})
 
 export default cozyConnect(mapDocumentsToProps, mapActionsToProps)(App)

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
+import { cozyConnect } from 'redux-cozy-client'
 
 import Sidebar from '../components/Sidebar'
 import Notifier from '../components/Notifier'
@@ -18,7 +18,8 @@ class App extends Component {
       categories: [],
       isFetching: true
     }
-    props.initialize(props.initKonnectors)
+
+    props.initializeRegistry(props.initKonnectors)
 
     this.store.fetchInitialData(props.domain)
       .then(() => {
@@ -64,9 +65,10 @@ class App extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
-  initialize: (initKonnectors) =>
-    dispatch(initializeRegistry(initKonnectors))
+const mapActionsToProps = (dispatch) => ({
+  initializeRegistry: (konnectors) => dispatch(initializeRegistry(konnectors))
 })
 
-export default connect(null, mapDispatchToProps)(App)
+const mapDocumentsToProps = (ownProps) => ({})
+
+export default cozyConnect(mapDocumentsToProps, mapActionsToProps)(App)

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -1,10 +1,13 @@
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 
 import Sidebar from '../components/Sidebar'
 import Notifier from '../components/Notifier'
 
 import Loading from '../components/Loading'
 import Failure from '../components/Failure'
+
+import { initializeRegistry } from '../ducks/registry'
 
 class App extends Component {
   constructor (props, context) {
@@ -15,6 +18,7 @@ class App extends Component {
       categories: [],
       isFetching: true
     }
+    props.initialize(props.initKonnectors)
 
     this.store.fetchInitialData(props.domain)
       .then(() => {
@@ -60,4 +64,9 @@ class App extends Component {
   }
 }
 
-export default App
+const mapDispatchToProps = (dispatch, ownProps) => ({
+  initialize: (initKonnectors) =>
+    dispatch(initializeRegistry(initKonnectors))
+})
+
+export default connect(null, mapDispatchToProps)(App)

--- a/src/ducks/konnectors/index.js
+++ b/src/ducks/konnectors/index.js
@@ -1,0 +1,7 @@
+import {
+  fetchCollection
+} from 'redux-cozy-client'
+
+export const DOCTYPE = 'io.cozy.konnectors'
+
+export const fetchKonnectors = () => fetchCollection('konnectors', DOCTYPE)

--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -1,0 +1,25 @@
+// constant
+const INITIALIZE_REGISTRY_KONNECTORS = 'INITIALIZE_REGISTRY_KONNECTORS'
+
+// reducers
+
+const initialState = { konnectors: [] }
+const registry = (state = initialState, action) => {
+  switch (action.type) {
+    case INITIALIZE_REGISTRY_KONNECTORS:
+      return {konnectors: action.konnectors}
+    default:
+      return state
+  }
+}
+
+export default registry
+
+// selectors
+
+export const getRegistryKonnectors = state => state.registry.konnectors
+export const getRegistryKonnector = (state, slug) => state.registry.konnectors.find(konnector => konnector.slug === slug)
+
+// action creators sync
+
+export const initializeRegistry = konnectors => ({type: INITIALIZE_REGISTRY_KONNECTORS, konnectors: konnectors})

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,9 +2,9 @@
 import 'babel-polyfill'
 import 'url-search-params-polyfill'
 import React from 'react'
-import { Provider } from 'react-redux'
 import { render } from 'react-dom'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
+import { CozyClient, CozyProvider } from 'redux-cozy-client'
 
 import { I18n } from 'cozy-ui/react/I18n'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
@@ -42,10 +42,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const root = document.querySelector('[role=application]')
   const data = root.dataset
-  cozy.client.init({
-    cozyURL: '//' + data.cozyDomain,
+
+  const client = new CozyClient({
+    cozyURL: `//${data.cozyDomain}`,
     token: data.cozyToken
   })
+
   cozy.bar.init({
     appEditor: data.cozyAppEditor,
     appName: data.cozyAppName,
@@ -55,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // store
-  const store = configureStore(initKonnectors, initFolders, context)
+  const store = configureStore(client, initKonnectors, initFolders, context)
   const useCases = store.getUseCases()
 
   let history = hashHistory
@@ -71,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
     : require(`./locales/${lang}`)
 
   render((
-    <Provider store={store}>
+    <CozyProvider store={store} client={client}>
       <I18n lang={lang} dictRequire={dictRequire} context={context}>
         <Router history={history}>
           <Route
@@ -135,6 +137,6 @@ document.addEventListener('DOMContentLoaded', () => {
           </Route>
         </Router>
       </I18n>
-    </Provider>
+    </CozyProvider>
   ), document.querySelector('[role=application]'))
 })

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
         <Router history={history}>
           <Route
             component={(props) =>
-              <App domain={data.cozyDomain} {...props}
+              <App domain={data.cozyDomain} initKonnectors={initKonnectors} {...props}
               />}
           >
             <Redirect from='/' to='/discovery' />

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,11 +2,12 @@
 import 'babel-polyfill'
 import 'url-search-params-polyfill'
 import React from 'react'
+import { Provider } from 'react-redux'
 import { render } from 'react-dom'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 
 import { I18n } from 'cozy-ui/react/I18n'
-import CollectStore, { Provider } from './lib/CollectStore'
+import CollectStore from './lib/CollectStore'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
 
 import App from './containers/App'

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,10 +7,10 @@ import { render } from 'react-dom'
 import { Router, Route, Redirect, hashHistory } from 'react-router'
 
 import { I18n } from 'cozy-ui/react/I18n'
-import CollectStore from './lib/CollectStore'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
 
 import App from './containers/App'
+import configureStore from './store/configureStore'
 import DiscoveryList from './components/DiscoveryList'
 import CategoryList from './components/CategoryList'
 import ConnectedList from './components/ConnectedList'
@@ -55,7 +55,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // store
-  const store = new CollectStore(initKonnectors, initFolders, context)
+  const store = configureStore(initKonnectors, initFolders, context)
   const useCases = store.getUseCases()
 
   let history = hashHistory

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -1,6 +1,4 @@
 /* global cozy */
-import { Component } from 'react'
-
 import * as accounts from './accounts'
 import * as konnectors from './konnectors'
 import * as jobs from './jobs'
@@ -556,20 +554,5 @@ export default class CollectStore {
     }
 
     return null
-  }
-}
-
-export class Provider extends Component {
-  getChildContext () {
-    return { store: this.store }
-  }
-
-  constructor (props, context) {
-    super(props, context)
-    this.store = props.store
-  }
-
-  render ({children}) {
-    return (children && children[0]) || null
   }
 }

--- a/src/lib/redux-cozy-client/CozyAPI.js
+++ b/src/lib/redux-cozy-client/CozyAPI.js
@@ -1,0 +1,154 @@
+/* global cozy */
+const FILES_DOCTYPE = 'io.cozy.files'
+const FETCH_LIMIT = 50
+
+export default class CozyAPI {
+  constructor (config) {
+    cozy.client.init(config)
+  }
+
+  async fetchDocuments (doctype) {
+    // WARN: cozy-client-js lacks a cozy.data.findAll method that uses this route
+    try {
+      // WARN: if no document of this doctype exist, this route will return a 404,
+      // so we need to try/catch and return an empty response object in case of a 404
+      const resp = await cozy.client.fetchJSON('GET', `/data/${doctype}/_all_docs?include_docs=true`)
+      // WARN: the JSON response from the stack is not homogenous with other routes (offset? rows? total_rows?)
+      // see https://github.com/cozy/cozy-stack/blob/master/docs/data-system.md#list-all-the-documents
+      // WARN: looks like this route returns something looking like a couchDB design doc, we need to filter it:
+      const rows = resp.rows.filter(row => !row.doc.hasOwnProperty('views'))
+      // we normalize the data (note that we add _type so that cozy.client.data.listReferencedFiles works...)
+      const docs = rows.map(row => Object.assign({}, row.doc, { id: row.id, type: doctype, _type: doctype }))
+      // we forge a correct JSONAPI response:
+      return {
+        data: docs,
+        meta: { count: resp.total_rows },
+        skip: resp.offset,
+        next: false
+      }
+    } catch (error) {
+      if (error.message.match(/not_found/)) {
+        return { data: [], meta: { count: 0 }, skip: 0, next: false }
+      }
+      throw error
+    }
+  }
+
+  async queryDocuments (doctype, index, options) {
+    const fields = options.fields
+    const skip = options.skip || 0
+    // Mango wants an array of single-property-objects...
+    const sort = options.sort
+      ? index.fields.map(f => ({ [f]: options.sort[f] || 'desc' }))
+      : undefined
+
+    const queryOptions = {
+      limit: FETCH_LIMIT,
+      wholeResponse: true, // WARN: mandatory to get the full JSONAPI response
+      ...options,
+      // TODO: type and class should not be necessary, it's just a temp fix for a stack bug
+      fields: [...fields, '_id', 'type', 'class'],
+      skip,
+      sort
+    }
+
+    // abstract away the format differences between query replies on the VFS versus the data API
+    let data, meta, next
+    if (doctype === FILES_DOCTYPE) {
+      const response = await cozy.client.files.query(index, queryOptions)
+      data = response.data.map(doc => Object.assign({ _id: doc.id }, doc, doc.attributes))
+      meta = response.meta
+      next = meta.count > skip + FETCH_LIMIT
+    } else {
+      const response = await cozy.client.data.query(index, queryOptions)
+      data = response.docs.map(doc => Object.assign({id: doc._id}, doc))
+      meta = {}
+      next = response.next
+    }
+
+    // we forge a correct JSONAPI response:
+    return { data, meta, next }
+  }
+
+  async fetchDocument (doctype, id) {
+    const doc = await cozy.client.data.find(doctype, id)
+    // we normalize again...
+    const normalized = { ...doc, id: doc._id, type: doc._type }
+    return { data: [normalized] }
+  }
+
+  async createDocument (doc) {
+    const created = await cozy.client.data.create(doc.type, doc)
+    // we forge a standard response with a 'data' property
+    const normalized = { ...created, id: created._id }
+    return { data: [normalized] }
+  }
+
+  async updateDocument (doc) {
+    const updated = await cozy.client.data.updateAttributes(doc.type, doc.id, doc)
+    // we forge a standard response with a 'data' property
+    return { data: [{...doc, _rev: updated._rev}] }
+  }
+
+  async deleteDocument (doc) {
+    /* const deleted = */ await cozy.client.data.delete(doc.type, doc)
+    // we forge a standard response with a 'data' property
+    return { data: [doc] }
+  }
+
+  async createIndex (doctype, fields) {
+    return await cozy.client.data.defineIndex(doctype, fields)
+  }
+
+  async fetchFileByPath (path) {
+    try {
+      const file = await cozy.client.files.statByPath(path)
+      // we forge a standard response with a 'data' property
+      return { data: [normalizeFile(file)] }
+    } catch (err) {
+      return null
+    }
+  }
+
+  async createFile (file, dirID) {
+    const created = await cozy.client.files.create(file, { dirID })
+    // we forge a standard response with a 'data' property
+    return { data: [normalizeFile(created)] }
+  }
+
+  async trashFile (file) {
+    /* const trashed = */ cozy.client.files.trashById(file.id)
+    // we forge a standard response with a 'data' property
+    return { data: [file] }
+  }
+
+  async fetchReferencedFiles (doc, skip = 0) {
+    // WARN: _type and _id are needed by cozy.client.data.fetchReferencedFiles
+    const normalized = { ...doc, _type: doc.type, _id: doc.id }
+    // WARN: the stack API is probably not ideal here: referencedFiles are in the 'included' property
+    // (that should be used when fetching an entity AND its relations) and the 'data' property
+    // only contains uplets { id, type }
+    const { included, meta } = await cozy.client.data.fetchReferencedFiles(normalized, { skip, limit: FETCH_LIMIT })
+    // we forge a standard response with a 'data' property
+    return {
+      data: !included ? [] : included.map(file => ({ ...file, ...file.attributes, type: 'io.cozy.files' })),
+      meta,
+      next: meta.count > skip + FETCH_LIMIT,
+      skip
+    }
+  }
+
+  async addReferencedFiles (doc, ids) {
+    await cozy.client.data.addReferencedFiles(doc, ids)
+    return ids
+  }
+
+  async removeReferencedFiles (doc, ids) {
+    // WARN: _type and _id are needed by cozy.client.data.removeReferencedFiles
+    const normalized = { ...doc, _type: doc.type, _id: doc.id }
+    await cozy.client.data.removeReferencedFiles(normalized, ids)
+    return ids
+  }
+}
+
+const normalizeFile = (file) => ({ ...file, ...file.attributes, id: file._id, type: file._type })

--- a/src/lib/redux-cozy-client/CozyClient.js
+++ b/src/lib/redux-cozy-client/CozyClient.js
@@ -1,0 +1,98 @@
+/* global cozy */
+import { CozyAPI } from '.'
+
+export default class CozyClient {
+  constructor (config) {
+    this.indexes = {}
+    this.specialDirectories = {}
+    this.api = new CozyAPI(config)
+  }
+
+  async fetchCollection (name, doctype, options = {}, skip = 0) {
+    if (options.selector) {
+      const index = await this.getCollectionIndex(name, doctype, options)
+      return await this.api.queryDocuments(doctype, index, {...options, skip})
+    }
+    return await this.api.fetchDocuments(doctype)
+  }
+
+  async fetchDocument (doctype, id) {
+    return this.api.fetchDocument(doctype, id)
+  }
+
+  async fetchFile (id) {
+    return this.api.fetchFile(id)
+  }
+
+  async fetchReferencedFiles (doc, skip = 0) {
+    return this.api.fetchReferencedFiles(doc, skip)
+  }
+
+  async addReferencedFiles (doc, ids) {
+    return this.api.addReferencedFiles(doc, ids)
+  }
+
+  async removeReferencedFiles (doc, ids) {
+    return this.api.removeReferencedFiles(doc, ids)
+  }
+
+  async createDocument (doc) {
+    return this.api.createDocument(doc)
+  }
+
+  async updateDocument (doc) {
+    return this.api.updateDocument(doc)
+  }
+
+  async deleteDocument (doc) {
+    return this.api.deleteDocument(doc)
+  }
+
+  async createFile (file, dirID) {
+    return this.api.createFile(file, dirID)
+  }
+
+  async trashFile (file) {
+    return this.api.trashFile(file)
+  }
+
+  async ensureDirectoryExists (path) {
+    if (!this.specialDirectories[path]) {
+      const dir = await cozy.client.files.createDirectoryByPath(path)
+      this.specialDirectories[path] = dir._id
+    }
+    return this.specialDirectories[path]
+  }
+
+  async checkUniquenessOf (doctype, property, value) {
+    const index = await this.getUniqueIndex(doctype, property)
+    const existingDocs = await cozy.client.data.query(index, {
+      selector: { [property]: value },
+      fields: ['_id']
+    })
+    return existingDocs.length === 0
+  }
+
+  async getCollectionIndex (name, doctype, options) {
+    if (!this.indexes[name]) {
+      this.indexes[name] = await this.api.createIndex(doctype, this.getIndexFields(options))
+    }
+    return this.indexes[name]
+  }
+
+  async getUniqueIndex (doctype, property) {
+    const name = `${doctype}/${property}`
+    if (!this.indexes[name]) {
+      this.indexes[name] = await this.api.createIndex(doctype, [property])
+    }
+    return this.indexes[name]
+  }
+
+  getIndexFields (options) {
+    const { selector, sort } = options
+    if (sort) {
+      return [...Object.keys(selector), ...Object.keys(sort)]
+    }
+    return Object.keys(selector)
+  }
+}

--- a/src/lib/redux-cozy-client/CozyProvider.jsx
+++ b/src/lib/redux-cozy-client/CozyProvider.jsx
@@ -1,0 +1,34 @@
+import { Component } from 'react'
+import PropTypes from 'prop-types'
+
+export default class CozyProvider extends Component {
+  static propTypes = {
+    store: PropTypes.shape({
+      subscribe: PropTypes.func.isRequired,
+      dispatch: PropTypes.func.isRequired,
+      getState: PropTypes.func.isRequired
+    }),
+    client: PropTypes.object.isRequired,
+    children: PropTypes.element.isRequired
+  }
+
+  static childContextTypes = {
+    store: PropTypes.object,
+    client: PropTypes.object.isRequired
+  }
+
+  static contextTypes = {
+    store: PropTypes.object
+  }
+
+  getChildContext () {
+    return {
+      store: this.props.store || this.context.store,
+      client: this.props.client
+    }
+  }
+
+  render () {
+    return (this.props.children && this.props.children[0]) || null
+  }
+}

--- a/src/lib/redux-cozy-client/README.md
+++ b/src/lib/redux-cozy-client/README.md
@@ -1,0 +1,6 @@
+# redux-cozy-client
+
+## TODO
+ - Add support for belongsTo/hasOne/hasMany associations: IDs preloading (using listReferencedFiles for instance),
+ count properties, etc. These associations would be defined in a doctype schema of some sort.
+ 

--- a/src/lib/redux-cozy-client/__tests__/store.spec.js
+++ b/src/lib/redux-cozy-client/__tests__/store.spec.js
@@ -1,0 +1,90 @@
+import { combineReducers } from 'redux'
+import { reducer as cozyReducer, fetchCollection, getCollection, createDocument } from '..'
+
+const reducer = combineReducers({ cozy: cozyReducer })
+const dispatchInitialAction = (compositeAction, initialState = undefined) => {
+  const { types, ...rest } = compositeAction
+  return reducer(initialState, { type: types[0], ...rest })
+}
+
+const dispatchSuccessfulAction = (compositeAction, response, initialState = undefined) => {
+  const { types, ...rest } = compositeAction
+  const actions = [
+    { type: types[0], ...rest },
+    { type: types[1], ...rest, response }
+  ]
+  return actions.reduce((state, action) => reducer(state, action), initialState)
+}
+
+describe('Redux store tests', () => {
+  describe('Given the store is empty', () => {
+    it('should return a default state', () => {
+      expect(getCollection(reducer(undefined, {}), 'rockets')).toEqual({
+        type: null,
+        fetchStatus: 'pending',
+        lastFetch: null,
+        hasMore: false,
+        count: 0,
+        ids: [],
+        data: null
+      })
+    })
+
+    describe('When a collection is fetched', () => {
+      it('should have a `loading` status', () => {
+        const state = dispatchInitialAction(fetchCollection('rockets', 'io.cozy.rockets'))
+        const collection = getCollection(state, 'rockets')
+        expect(collection.fetchStatus).toBe('loading')
+      })
+    })
+  })
+
+  const fakeFetchResponse = {
+    data: [
+      { id: '33dda00f0eec15bc3b3c59a615001ac7', type: 'io.cozy.rockets', name: 'Falcon 9' },
+      { id: '33dda00f0eec15bc3b3c59a615001ac8', type: 'io.cozy.rockets', name: 'Falcon Heavy' },
+      { id: '33dda00f0eec15bc3b3c59a615001ac9', type: 'io.cozy.rockets', name: 'BFR' }
+    ]
+  }
+
+  describe('Given a collection has been successfully fetched', () => {
+    let state, collection
+
+    beforeEach(() => {
+      state = dispatchSuccessfulAction(fetchCollection('rockets', 'io.cozy.rockets'), fakeFetchResponse)
+      collection = getCollection(state, 'rockets')
+    })
+
+    it('should have a `loaded` status', () => {
+      expect(collection.fetchStatus).toBe('loaded')
+    })
+
+    it('should have a `data` property with the list of documents', () => {
+      expect(collection.data).toEqual(fakeFetchResponse.data)
+    })
+
+    describe('When a document is successfully created on the server', () => {
+      const fakeResponse = {
+        data: [
+          { id: '33dda00f0eec15bc3b3c59a615001ac5', type: 'io.cozy.rockets', name: 'Saturn V' }
+        ]
+      }
+
+      it('should be found in the store', () => {
+
+      })
+
+      it('should update collections listed in the `updateCollections` option', () => {
+        state = dispatchSuccessfulAction(
+          createDocument({ type: 'io.cozy.rockets', name: 'Saturn V' }, {
+            updateCollections: ['rockets']
+          }),
+          fakeResponse,
+          state
+        )
+        collection = getCollection(state, 'rockets')
+        expect(collection.data[3]).toEqual(fakeResponse.data[0])
+      })
+    })
+  })
+})

--- a/src/lib/redux-cozy-client/connect.jsx
+++ b/src/lib/redux-cozy-client/connect.jsx
@@ -1,0 +1,72 @@
+import React, { Component } from 'react'
+import { connect as reduxConnect } from 'react-redux'
+
+import { getCollection, getDocument } from '.'
+import { mapValues, filterValues } from './utils'
+import { makeFetchMoreAction } from './reducer'
+
+const isFetchCollection = (action) => action.types[0] === 'FETCH_COLLECTION' || action.types[0] === 'FETCH_REFERENCED_FILES'
+
+const enhanceProps = (props, fetchActions, dispatch) => mapValues(fetchActions, (action, propName) => {
+  const dataObject = props[propName]
+  if (!isFetchCollection(action)) {
+    return dataObject
+  }
+  const fetchMore = dataObject.hasMore
+    ? () => dispatch(makeFetchMoreAction(action, dataObject.data.length))
+    : null
+  return {
+    ...dataObject,
+    fetchMore
+  }
+})
+
+const connect = (mapDocumentsToProps, mapActionsToProps = null) => (WrappedComponent) => {
+  class Wrapper extends Component {
+    componentDidMount () {
+      const { fetchActions } = this.props
+      const dispatch = this.context.store.dispatch
+      for (const propName in fetchActions) {
+        dispatch(fetchActions[propName])
+      }
+    }
+
+    render () {
+      const { t, f, client, store } = this.context
+      const { fetchActions } = this.props
+      const props = {
+        t,
+        f,
+        client,
+        ...this.props,
+        ...enhanceProps(this.props, fetchActions, store.dispatch)
+      }
+      return <WrappedComponent {...props} />
+    }
+  }
+
+  const makeMapStateToProps = (initialState, initialOwnProps) => {
+    const initialProps = mapDocumentsToProps(initialOwnProps)
+
+    const isAction = (action) => action && action.types && action.promise
+    const fetchActions = filterValues(initialProps, (prop) => isAction(prop))
+    const otherProps = filterValues(initialProps, (prop) => !isAction(prop))
+
+    const selector = (state, action) => {
+      return isFetchCollection(action)
+      ? getCollection(state, action.collection)
+      : getDocument(state, action.doctype, action.id)
+    }
+
+    const mapStateToProps = (state) => ({
+      ...mapValues(fetchActions, (action) => isAction(action) ? selector(state, action) : action),
+      fetchActions,
+      ...otherProps
+    })
+    return mapStateToProps
+  }
+
+  return reduxConnect(makeMapStateToProps, mapActionsToProps)(Wrapper)
+}
+
+export default connect

--- a/src/lib/redux-cozy-client/helpers.js
+++ b/src/lib/redux-cozy-client/helpers.js
@@ -1,0 +1,34 @@
+/* global cozy */
+
+const slugify = (text) =>
+  text.toString().toLowerCase()
+    .replace(/\s+/g, '-')           // Replace spaces with -
+    .replace(/[^\w-]+/g, '')       // Remove all non-word chars
+    .replace(/--+/g, '-')         // Replace multiple - with single -
+    .replace(/^-+/, '')             // Trim - from start of text
+    .replace(/-+$/, '')             // Trim - from end of text
+
+const forceFileDownload = (href, filename) => {
+  const element = document.createElement('a')
+  element.setAttribute('href', href)
+  element.setAttribute('download', filename)
+  element.style.display = 'none'
+  document.body.appendChild(element)
+  element.click()
+  document.body.removeChild(element)
+}
+
+// async helpers: they interact with the stack but not with the store
+export const downloadArchive = async (notSecureFilename, fileIds) => {
+  const filename = slugify(notSecureFilename)
+  const href = await cozy.client.files.getArchiveLinkByIds(fileIds, filename)
+  const fullpath = await cozy.client.fullpath(href)
+  forceFileDownload(fullpath, filename + '.zip')
+}
+
+export const downloadFile = async (file) => {
+  const response = await cozy.client.files.downloadById(file.id)
+  const blob = await response.blob()
+  const filename = file.name
+  forceFileDownload(window.URL.createObjectURL(blob), filename)
+}

--- a/src/lib/redux-cozy-client/index.js
+++ b/src/lib/redux-cozy-client/index.js
@@ -1,0 +1,24 @@
+export { default as CozyProvider } from './CozyProvider'
+export { default as CozyAPI } from './CozyAPI'
+export { default as CozyClient } from './CozyClient'
+export { default as cozyConnect } from './connect'
+export { default as cozyMiddleware } from './middleware'
+export {
+  default as reducer,
+  makeActionCreator,
+  fetchCollection,
+  fetchDocument,
+  fetchReferencedFiles,
+  addReferencedFiles,
+  removeReferencedFiles,
+  getCollection,
+  getDocument,
+  createDocument,
+  updateDocument,
+  deleteDocument,
+  createFile,
+  trashFile,
+  CREATE_DOCUMENT
+} from './reducer'
+
+export { downloadArchive, downloadFile } from './helpers'

--- a/src/lib/redux-cozy-client/middleware.js
+++ b/src/lib/redux-cozy-client/middleware.js
@@ -1,0 +1,41 @@
+const cozyMiddleware = (client) => ({ dispatch, getState }) => {
+  return next => action => {
+    const { promise, type, types, ...rest } = action
+    if (!promise) {
+      return next(action)
+    }
+
+    if (!type && !types) {
+      return promise(client)
+        .then((action) => dispatch(action))
+    }
+
+    if (type) {
+      return promise(client)
+        .then((response) => {
+          next({...rest, response, type})
+          return response
+        })
+    }
+
+    const [REQUEST, SUCCESS, FAILURE] = types
+    next({...rest, type: REQUEST})
+
+    return promise(client)
+      .then(
+        (response) => {
+          next({...rest, response, type: SUCCESS})
+          return response
+        },
+        (error) => {
+          console.log(error)
+          next({...rest, error, type: FAILURE})
+        }
+      ).catch((error) => {
+        console.error('MIDDLEWARE ERROR:', error)
+        next({...rest, error, type: FAILURE})
+      })
+  }
+}
+
+export default cozyMiddleware

--- a/src/lib/redux-cozy-client/reducer.js
+++ b/src/lib/redux-cozy-client/reducer.js
@@ -1,0 +1,313 @@
+import { combineReducers } from 'redux'
+import { removeObjectProperty } from './utils'
+
+const FETCH_DOCUMENT = 'FETCH_DOCUMENT'
+const FETCH_COLLECTION = 'FETCH_COLLECTION'
+const RECEIVE_DATA = 'RECEIVE_DATA'
+const RECEIVE_ERROR = 'RECEIVE_ERROR'
+export const CREATE_DOCUMENT = 'CREATE_DOCUMENT'
+const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'
+const DELETE_DOCUMENT = 'DELETE_DOCUMENT'
+const RECEIVE_NEW_DOCUMENT = 'RECEIVE_NEW_DOCUMENT'
+const RECEIVE_UPDATED_DOCUMENT = 'RECEIVE_UPDATED_DOCUMENT'
+const RECEIVE_DELETED_DOCUMENT = 'RECEIVE_DELETED_DOCUMENT'
+const FETCH_REFERENCED_FILES = 'FETCH_REFERENCED_FILES'
+const ADD_REFERENCED_FILES = 'ADD_REFERENCED_FILES'
+const REMOVE_REFERENCED_FILES = 'REMOVE_REFERENCED_FILES'
+
+const documents = (state = {}, action) => {
+  switch (action.type) {
+    case RECEIVE_DATA:
+      const { data } = action.response
+      if (data.length === 0) return state
+      const dataDoctype = getArrayDoctype(data)
+      return {
+        ...state,
+        [dataDoctype]: {
+          ...state[dataDoctype],
+          ...objectifyDocumentsArray(data)
+        }
+      }
+    case RECEIVE_NEW_DOCUMENT:
+    case RECEIVE_UPDATED_DOCUMENT:
+      const doc = action.response.data[0]
+      return {
+        ...state,
+        [doc.type]: {
+          ...state[doc.type],
+          [doc.id]: doc
+        }
+      }
+    case RECEIVE_DELETED_DOCUMENT:
+      const deleted = action.response.data[0]
+      return {
+        ...state,
+        [deleted.type]: removeObjectProperty(state[deleted.type], deleted.id)
+      }
+    case ADD_REFERENCED_FILES:
+      return {
+        ...state,
+        'io.cozy.files': {
+          ...state['io.cozy.files'],
+          ...updateFilesReferences(state['io.cozy.files'], action.ids, action.document)
+        }
+      }
+    case REMOVE_REFERENCED_FILES:
+      return {
+        ...state,
+        'io.cozy.files': {
+          ...state['io.cozy.files'],
+          ...removeFilesReferences(state['io.cozy.files'], action.ids, action.document)
+        }
+      }
+    default:
+      return state
+  }
+}
+
+const objectifyDocumentsArray = (documents) => {
+  let obj = {}
+  documents.forEach(doc => { obj[doc.id] = doc })
+  return obj
+}
+
+const updateFilesReferences = (files, newlyReferencedIds, doc) => {
+  let updated = {}
+  newlyReferencedIds.forEach(id => {
+    const file = files[id]
+    file.relationships.referenced_by.data = file.relationships.referenced_by.data === null
+      ? [{ id: doc.id, type: doc.type }]
+      : [...file.relationships.referenced_by.data, { id: doc.id, type: doc.type }]
+    updated[id] = file
+  })
+  return updated
+}
+
+const removeFilesReferences = (files, removedIds, doc) => {
+  let updated = {}
+  removedIds.forEach(id => {
+    const file = files[id]
+    file.relationships.referenced_by.data =
+      file.relationships.referenced_by.data.filter(rel => rel.type !== doc.type && rel.id !== doc.id)
+    updated[id] = file
+  })
+  return updated
+}
+
+const getArrayDoctype = (documents) => {
+  const doctype = documents[0].type
+  // TODO: don't know why the stack returns 'file' here..
+  if (doctype === 'file') {
+    return 'io.cozy.files'
+  }
+  return doctype
+}
+
+// collection reducers
+const collectionInitialState = {
+  type: null,
+  fetchStatus: 'pending',
+  lastFetch: null,
+  hasMore: false,
+  count: 0,
+  ids: []
+}
+
+const collection = (state = collectionInitialState, action) => {
+  switch (action.type) {
+    case FETCH_COLLECTION:
+    case FETCH_REFERENCED_FILES:
+      return {
+        ...state,
+        type: action.doctype || 'io.cozy.files',
+        fetchStatus: action.skip > 0 ? 'loadingMore' : 'loading'
+      }
+    case RECEIVE_DATA:
+      const response = action.response
+      return {
+        ...state,
+        fetchStatus: 'loaded',
+        lastFetch: Date.now(),
+        hasMore: response.next !== undefined ? response.next : state.hasMore,
+        count: response.meta && response.meta.count ? response.meta.count : response.data.length,
+        ids: !action.skip ? response.data.map(doc => doc.id) : [...state.ids, ...response.data.map(doc => doc.id)]
+      }
+    case ADD_REFERENCED_FILES:
+      return {
+        ...state,
+        type: 'io.cozy.files',
+        count: state.count + action.ids.length,
+        ids: [...state.ids, ...action.ids]
+      }
+    case REMOVE_REFERENCED_FILES:
+      return {
+        ...state,
+        count: state.count - action.ids.length,
+        ids: state.ids.filter(id => action.ids.indexOf(id) === -1)
+      }
+    case RECEIVE_ERROR:
+      return {
+        ...state,
+        fetchStatus: 'failed'
+      }
+    case RECEIVE_NEW_DOCUMENT:
+      return {
+        ...state,
+        ids: [...state.ids, action.response.data[0].id]
+      }
+    case RECEIVE_DELETED_DOCUMENT:
+      return {
+        ...state,
+        ids: state.ids.filter(id => id !== action.response.data[0].id)
+      }
+    default:
+      return state
+  }
+}
+
+const collections = (state = {}, action) => {
+  const applyUpdate = (collections, updateAction) => {
+    let updated = {}
+    for (const name of updateAction.updateCollections) {
+      updated[name] = collection(collections[name], action)
+    }
+    return updated
+  }
+
+  switch (action.type) {
+    case FETCH_COLLECTION:
+    case FETCH_REFERENCED_FILES:
+    case ADD_REFERENCED_FILES:
+    case REMOVE_REFERENCED_FILES:
+    case RECEIVE_DATA:
+    case RECEIVE_ERROR:
+      if (!action.collection) {
+        return state
+      }
+      return {
+        ...state,
+        [action.collection]: collection(state[action.collection], action)
+      }
+    case RECEIVE_NEW_DOCUMENT:
+    case RECEIVE_DELETED_DOCUMENT:
+      if (!action.updateCollections) {
+        return state
+      }
+      return {
+        ...state,
+        ...applyUpdate(state, action)
+      }
+    default:
+      return state
+  }
+}
+
+export default combineReducers({
+  collections,
+  documents
+})
+
+export const fetchCollection = (name, doctype, options = {}, skip = 0) => ({
+  types: [FETCH_COLLECTION, RECEIVE_DATA, RECEIVE_ERROR],
+  collection: name,
+  doctype,
+  options,
+  skip,
+  promise: (client) => client.fetchCollection(name, doctype, options, skip)
+})
+
+export const fetchDocument = (doctype, id) => ({
+  types: [FETCH_DOCUMENT, RECEIVE_DATA, RECEIVE_ERROR],
+  doctype,
+  id,
+  promise: (client) => client.fetchDocument(doctype, id)
+})
+
+export const fetchReferencedFiles = (doc, skip = 0) => ({
+  types: [FETCH_REFERENCED_FILES, RECEIVE_DATA, RECEIVE_ERROR],
+  collection: `${doc.type}/${doc.id}#files`,
+  document: doc,
+  options: {},
+  skip,
+  promise: (client) => client.fetchReferencedFiles(doc, skip)
+})
+
+export const createDocument = (doc, actionOptions = {}) => ({
+  types: [CREATE_DOCUMENT, RECEIVE_NEW_DOCUMENT, RECEIVE_ERROR],
+  document: doc,
+  promise: (client) => client.createDocument(doc),
+  ...actionOptions
+})
+
+export const updateDocument = (doc, actionOptions = {}) => ({
+  types: [UPDATE_DOCUMENT, RECEIVE_UPDATED_DOCUMENT, RECEIVE_ERROR],
+  document: doc,
+  promise: (client) => client.updateDocument(doc),
+  ...actionOptions
+})
+
+export const deleteDocument = (doc, actionOptions = {}) => ({
+  types: [DELETE_DOCUMENT, RECEIVE_DELETED_DOCUMENT, RECEIVE_ERROR],
+  document: doc,
+  promise: (client) => client.deleteDocument(doc),
+  ...actionOptions
+})
+
+export const createFile = (file, dirID, actionOptions = {}) => ({
+  types: [CREATE_DOCUMENT, RECEIVE_NEW_DOCUMENT, RECEIVE_ERROR],
+  doctype: 'io.cozy.files',
+  promise: (client) => client.createFile(file, dirID),
+  ...actionOptions
+})
+
+export const trashFile = (file, actionOptions = {}) => ({
+  types: [DELETE_DOCUMENT, RECEIVE_DELETED_DOCUMENT, RECEIVE_ERROR],
+  document: file,
+  promise: (client) => client.trashFile(file),
+  ...actionOptions
+})
+
+export const addReferencedFiles = (doc, ids) => ({
+  type: ADD_REFERENCED_FILES,
+  collection: `${doc.type}/${doc.id}#files`,
+  document: doc,
+  ids,
+  promise: (client) => client.addReferencedFiles(doc, ids)
+})
+
+export const removeReferencedFiles = (doc, ids) => ({
+  type: REMOVE_REFERENCED_FILES,
+  collection: `${doc.type}/${doc.id}#files`,
+  document: doc,
+  ids,
+  promise: (client) => client.removeReferencedFiles(doc, ids)
+})
+
+export const makeActionCreator = (promise) => ({ promise })
+
+export const makeFetchMoreAction = ({ types, collection, document, doctype, options }, skip) =>
+  types[0] === FETCH_REFERENCED_FILES
+  ? fetchReferencedFiles(document, skip)
+  : fetchCollection(collection, doctype, options, skip)
+
+// selectors
+const mapDocumentsToIds = (documents, doctype, ids) => ids.map(id => documents[doctype][id])
+
+export const getCollection = (state, name) => {
+  const collection = state.cozy.collections[name]
+  if (!collection) {
+    return { ...collectionInitialState, data: null }
+  }
+  return {
+    ...collection,
+    data: mapDocumentsToIds(state.cozy.documents, collection.type, collection.ids)
+  }
+}
+
+export const getDocument = (state, doctype, id) => {
+  const documents = state.cozy.documents[doctype]
+  if (!documents) {
+    return null
+  }
+  return documents[id]
+}

--- a/src/lib/redux-cozy-client/utils.js
+++ b/src/lib/redux-cozy-client/utils.js
@@ -1,0 +1,26 @@
+export const mapValues = (object, transform) => {
+  let result = {}
+  for (const key in object) {
+    result[key] = transform(object[key], key)
+  }
+  return result
+}
+
+export const filterValues = (object, filter) => {
+  let result = {}
+  for (const key in object) {
+    if (filter(object[key], key)) {
+      result[key] = object[key]
+    }
+  }
+  return result
+}
+
+export const removeObjectProperty = (obj, prop) => {
+  return Object.keys(obj).reduce((result, key) => {
+    if (key !== prop) {
+      result[key] = obj[key]
+    }
+    return result
+  }, {})
+}

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,0 +1,1 @@
+export default () => (state) => state

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,1 +1,9 @@
-export default () => (state) => state
+import { combineReducers } from 'redux'
+
+import { reducer } from 'redux-cozy-client'
+import registry from '../ducks/registry'
+
+export default () => combineReducers({
+  cozy: reducer,
+  registry
+})

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,0 +1,11 @@
+import { createStore } from 'redux'
+import CollectStore from '../lib/CollectStore'
+import getReducers from '../reducers'
+
+const configureStore = (initKonnectors, initFolders, context) => {
+  const reduxStore = createStore(getReducers())
+
+  return Object.assign(new CollectStore(initKonnectors, initFolders, context), reduxStore)
+}
+
+export default configureStore

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,9 +1,17 @@
-import { createStore } from 'redux'
+/* global __DEVTOOLS__ */
+import { compose, createStore, applyMiddleware } from 'redux'
+import { createLogger } from 'redux-logger'
 import CollectStore from '../lib/CollectStore'
 import getReducers from '../reducers'
 
 const configureStore = (initKonnectors, initFolders, context) => {
-  const reduxStore = createStore(getReducers())
+  // Enable Redux dev tools
+  const composeEnhancers = (__DEVTOOLS__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
+
+  const reduxStore = createStore(
+    getReducers(),
+    composeEnhancers(applyMiddleware.apply(this, [createLogger()]))
+  )
 
   return Object.assign(new CollectStore(initKonnectors, initFolders, context), reduxStore)
 }

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,16 +1,19 @@
 /* global __DEVTOOLS__ */
 import { compose, createStore, applyMiddleware } from 'redux'
+import { cozyMiddleware } from 'redux-cozy-client'
 import { createLogger } from 'redux-logger'
+import thunkMiddleware from 'redux-thunk'
+
 import CollectStore from '../lib/CollectStore'
 import getReducers from '../reducers'
 
-const configureStore = (initKonnectors, initFolders, context) => {
+const configureStore = (client, initKonnectors, initFolders, context) => {
   // Enable Redux dev tools
   const composeEnhancers = (__DEVTOOLS__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
 
   const reduxStore = createStore(
     getReducers(),
-    composeEnhancers(applyMiddleware.apply(this, [createLogger()]))
+    composeEnhancers(applyMiddleware.apply(this, [cozyMiddleware(client), thunkMiddleware, createLogger()]))
   )
 
   return Object.assign(new CollectStore(initKonnectors, initFolders, context), reduxStore)

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,6 +468,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
@@ -495,6 +499,15 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-helper-remap-async-to-generator "^6.24.1"
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -5009,6 +5022,10 @@ redux-logger@^3.0.6:
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
   dependencies:
     deep-diff "^0.3.5"
+
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
 redux@^3.7.2:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1711,6 +1711,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-diff@^0.3.5:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+
 deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
@@ -4999,6 +5003,12 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-logger@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+  dependencies:
+    deep-diff "^0.3.5"
 
 redux@^3.7.2:
   version "3.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,6 +301,15 @@ babel-core@^6.0.0, babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
+babel-eslint@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
+
 babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
@@ -876,7 +885,7 @@ babel-template@^6.16.0, babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -890,7 +899,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -902,6 +911,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1:
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.16.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
+
+babylon@^6.17.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
 backo2@1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2699,6 +2699,10 @@ hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
 
+hoist-non-react-statics@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.0.tgz#ede16318c2ff1f9fe3a025396ba06fd4c44608bb"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -2907,7 +2911,7 @@ intro.js@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/intro.js/-/intro.js-2.5.0.tgz#8d6d48e79b7d3f649492888be30c8528a31aa2e7"
 
-invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.0.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3558,6 +3562,10 @@ localtunnel@1.8.1:
     request "2.65.0"
     yargs "3.29.0"
 
+lodash-es@^4.2.0, lodash-es@^4.2.1:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz#76e7b7c1f1fb92547374878a562ed06a3e50f6e1"
@@ -3727,7 +3735,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
+lodash@4.x.x, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.14.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4857,6 +4865,17 @@ react-markdown@^2.5.0:
     in-publish "^2.0.0"
     prop-types "^15.5.1"
 
+react-redux@^5.0.6:
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"
+  dependencies:
+    hoist-non-react-statics "^2.2.1"
+    invariant "^2.0.0"
+    lodash "^4.2.0"
+    lodash-es "^4.2.0"
+    loose-envify "^1.1.0"
+    prop-types "^15.5.10"
+
 react-router@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.0.3.tgz#e95304b2e418482e5ecff2699d2b8aae52d5f884"
@@ -4980,6 +4999,15 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
 
 regenerate@^1.2.1:
   version "1.3.2"
@@ -5706,6 +5734,10 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"


### PR DESCRIPTION
I tried to make the more commit as possible to log every step of adding redux and redux-cozy-client.

From now, the redux store is merged with the old one, and do not interfere with existing features.

About the registry duck:
It takes the konnector from the existing config file, but it will evolve in the future to fetch them from cozy-store/registry. For now it was a simple case to test, first for redux, second for having a custom state with a redux-cozy-client state.