### PR TITLE
Specify the jobs permissions

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -50,7 +50,10 @@
     },
     "jobs": {
       "description": "Required to run the konnectors",
-      "type": "io.cozy.jobs"
+      "type": "io.cozy.jobs",
+      "verbs": ["ALL"],
+      "selector": "worker",
+      "values": ["konnector"]
     },
     "triggers": {
       "description": "Required to run the konnectors",


### PR DESCRIPTION
Specify the jobs permissions to explicitly ask for the `konnector` worker. This evolution is required by this change in cozy-stack: https://github.com/cozy/cozy-stack/pull/950