### PR TITLE
Fix autocomplete proposal

### DIFF
--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -18,6 +18,9 @@ const Field = (props) => {
     )
   } else {
     const { type, placeholder, value, onChange, onInput, disabled, readOnly, name, noAutoFill } = props
+    const autoFill = noAutoFill
+      ? type === 'password' ? 'new-password' : 'off'
+      : 'on'
     inputs = (
       <input
         type={type}
@@ -29,7 +32,7 @@ const Field = (props) => {
         name={name}
         onChange={onChange}
         onInput={onInput}
-        autocomplete={noAutoFill ? 'new-password' : 'on'}
+        autocomplete={autoFill}
       />
     )
   }
@@ -90,6 +93,9 @@ export const PasswordField = translate()(
   }))(
     props => {
       const { t, placeholder, value, onChange, onInput, toggleVisibility, visible, name, giveFocus, noAutoFill } = props
+      const autoFill = noAutoFill
+        ? visible ? 'off' : 'new-password'
+        : 'on'
       return (
         <FieldWrapper giveFocus={props.type !== 'hidden' && giveFocus} {...props}>
           <button
@@ -112,7 +118,7 @@ export const PasswordField = translate()(
             name={name}
             onChange={onChange}
             onInput={onInput}
-            autocomplete={noAutoFill ? 'new-password' : 'on'}
+            autocomplete={autoFill}
           />
         </FieldWrapper>
       )


### PR DESCRIPTION
Autocomplete seems to still appear on password we reveal it (so it become a text input).
This changes try to keep the autocomplete disabled in all cases.

Insteresting links:
[MDN autocomplete and login fields](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields)
[HTML Spec autocomplete](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password)