### PR TITLE
feat: prevent mulitple OAuth accounts creation ✨

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -7,7 +7,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import Field, { PasswordField, DropdownField, CheckboxField, isHidden, isAdvanced } from './Field'
 import ReactMarkdownWrapper from './ReactMarkdownWrapper'
 
-const AccountLoginForm = ({ t, isOAuth, oAuthTerminated, fields, error, dirty, submitting, forceEnabled, values, submit, connectorSlug, isSuccess, disableSuccessTimeout, isUnloading }) => {
+const AccountLoginForm = ({ t, isOAuth, oAuthTerminated, fields, error, dirty, submitting, forceDisabled, forceEnabled, values, submit, connectorSlug, isSuccess, disableSuccessTimeout, isUnloading }) => {
   const isUpdate = !!values && Object.keys(values).length > 0
   let alreadyFocused = false
   const editableFields = Object.keys(fields)
@@ -88,7 +88,7 @@ const AccountLoginForm = ({ t, isOAuth, oAuthTerminated, fields, error, dirty, s
         { ((!isUpdate || hasEditableFields) && !isSuccess) &&
           <button
             className={classNames('coz-btn', 'coz-btn--regular', styles['coz-btn'])}
-            disabled={submitting || !submitEnabled}
+            disabled={forceDisabled || submitting || !(submitEnabled)}
             aria-busy={submitting && !disableSuccessTimeout && (isUpdate || !isOAuth || oAuthTerminated) ? 'true' : 'false'}
             onClick={submit}
           >

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -9,7 +9,7 @@ import KonnectorSuccess from './KonnectorSuccess'
 
 import { ACCOUNT_ERRORS } from '../lib/accounts'
 
-export const KonnectorInstall = ({ t, account, connector, deleting, disableSuccessTimeout, driveUrl, error, fields, folderPath, isTimeout, isUnloading, oAuthTerminated, onAccountConfig, onCancel, onDelete, onSubmit, submitting, success }) => {
+export const KonnectorInstall = ({ t, account, connector, deleting, disableSuccessTimeout, driveUrl, error, fields, forceDisabled, folderPath, isTimeout, isUnloading, oAuthTerminated, onAccountConfig, onCancel, onDelete, onSubmit, submitting, success }) => {
   const securityIcon = require('../assets/icons/color/icon-cloud-lock.svg')
   const { hasDescriptions } = connector
 
@@ -43,6 +43,7 @@ export const KonnectorInstall = ({ t, account, connector, deleting, disableSucce
           error={error && error.message === ACCOUNT_ERRORS.LOGIN_FAILED}
           fields={fields}
           forceEnabled={!!error}
+          forceDisabled={forceDisabled}
           isOAuth={connector.oauth}
           isUnloading={isUnloading}
           oAuthTerminated={oAuthTerminated}

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -322,6 +322,7 @@ class AccountConnection extends Component {
             error={error}
             fields={fields}
             folderPath={folderPath}
+            forceDisabled={oAuthTerminated}
             isTimeout={isTimeout}
             isUnloading={isUnloading}
             oAuthTerminated={oAuthTerminated}


### PR DESCRIPTION
When errors were occuring in Cozy-Collect or during job run, it was possible to try a new connection.

In the stack, this was resulting with the creation of a new account. It may occurred that multiple accounts were coexisting in DB, one by error.

The goal of this PR is to prevent this case to happen by disabling the connection form once one OAuth process has been terminated. The only way next for users is to try again in the edition modal or to delete their account.