### PR TITLE
feat: improve form

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -103,6 +103,7 @@ const AccountLoginForm = props => {
       invalid: !!error,
       onEnterKey,
       giveFocus,
+      connectorSlug,
       label: t(`account.form.label.${label || name}`),
       value: isUnloading ? '' : hydrate(value)
     }
@@ -119,8 +120,12 @@ const AccountLoginForm = props => {
   }
 
   return (
-    // We use a <div> instead of a <form> to disable the "use password for" function of Chrome
-    <div className={styles['account-form-login']}>
+    <form
+      role="form"
+      className={styles['account-form-login']}
+      onSubmit={submit}
+      name={connectorSlug}
+    >
       {/* Error */}
       {error && (
         <p className="errors">{t('account.message.error.bad_credentials')}</p>
@@ -158,7 +163,6 @@ const AccountLoginForm = props => {
                   ? 'true'
                   : 'false'
               }
-              onClick={submit}
             >
               {t(
                 isUpdate
@@ -168,7 +172,7 @@ const AccountLoginForm = props => {
             </button>
           )}
       </div>
-    </div>
+    </form>
   )
 }
 

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -22,6 +22,7 @@ const Field = props => {
     const {
       type,
       placeholder,
+      connectorSlug,
       value,
       pattern,
       onChange,
@@ -29,16 +30,13 @@ const Field = props => {
       onInput,
       disabled,
       readOnly,
-      name,
-      noAutoFill
+      name
     } = props
-    const autoFill = noAutoFill
-      ? type === 'password' ? 'new-password' : 'off'
-      : 'on'
     inputs = (
       <input
         type={type}
         placeholder={placeholder}
+        autoComplete={`${connectorSlug} ${name}`}
         className={styles['coz-field-input']}
         readOnly={readOnly}
         disabled={disabled || readOnly}
@@ -48,7 +46,6 @@ const Field = props => {
         onChange={onChange}
         onBlur={onBlur}
         onInput={onInput}
-        autoComplete={autoFill}
       />
     )
   }
@@ -72,11 +69,6 @@ export class FieldWrapper extends Component {
         .focus()
   }
 
-  handleKeyUp = ev => {
-    const key = ev.which || ev.keyCode
-    if (key === 13) this.props.onEnterKey()
-  }
-
   render() {
     const { label, invalid, errors, children } = this.props
     const hasErrored = errors.length !== 0 || invalid
@@ -87,7 +79,6 @@ export class FieldWrapper extends Component {
           styles['coz-field'],
           hasErrored && styles['coz-field--error']
         )}
-        onKeyUp={this.props.onEnterKey && this.handleKeyUp}
       >
         {label && <label>{label}</label>}
         {children}
@@ -115,6 +106,7 @@ export const PasswordField = translate()(
   )(props => {
     const {
       t,
+      connectorSlug,
       placeholder,
       value,
       onChange,
@@ -124,10 +116,8 @@ export const PasswordField = translate()(
       toggleVisibility,
       visible,
       name,
-      giveFocus,
-      noAutoFill
+      giveFocus
     } = props
-    const autoFill = noAutoFill ? (visible ? 'off' : 'new-password') : 'on'
     return (
       <FieldWrapper giveFocus={props.type !== 'hidden' && giveFocus} {...props}>
         <button
@@ -147,6 +137,7 @@ export const PasswordField = translate()(
         </button>
         <input
           type={visible ? 'text' : 'password'}
+          autoComplete={`${connectorSlug} password`}
           placeholder={placeholder}
           className={styles['coz-field-input']}
           value={value}
@@ -155,7 +146,6 @@ export const PasswordField = translate()(
           onChange={onChange}
           onInput={onInput}
           onBlur={onBlur}
-          autoComplete={autoFill}
         />
       </FieldWrapper>
     )

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -271,6 +271,7 @@ class AccountConnection extends Component {
 
   // @param isUpdate : used to force updating values not related to OAuth
   submit(values) {
+    event.preventDefault()
     this.setState({
       error: null
     })


### PR DESCRIPTION
Tentative du dimanche soir de revenir à quelque de plus propre...

+ retour à un `<form>` au lieu d'un `<div>`
+ suppression du `onEnterKey` qui simule la touche entrée, plus besoin avec un vrai <form>, et ça provoquait au moins 2 bugs (cf Trello)

Ça devrait permettre aussi d'utiliser l'attribut `required`, la validation client-side html5, etc.

Ça provoque une régression, les konnectors non installés sont pré-remplis avec des logins / pass déjà enregistrés. C'est le comportement implémenté par le navigateur, comme dit la formule "c'est pas un bug, c'est une feature". Je veux bien défendre cette feature, contre tous les inconvénients que vont provoquer le fait d'aller contre ce comportement en devant réinventer la roue comme on le faisait aujourd'hui.
