### PR TITLE
fix: make OAuth form valid 🚑

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -38,7 +38,7 @@ const hydrateFieldValue = {
 
 const identity = x => x
 
-const AccountLoginForm = props => {
+export const AccountLoginForm = props => {
   const {
     t,
     isOAuth,

--- a/src/lib/statefulForm.jsx
+++ b/src/lib/statefulForm.jsx
@@ -13,7 +13,8 @@ export default function statefulForm(mapPropsToFormConfig) {
           dirty: false,
           submit: this.handleSubmit.bind(this),
           oauth: props.onOAuth,
-          displayAdvanced: false
+          displayAdvanced: false,
+          isValid: true
         }
       }
 

--- a/test/components/AccountLoginForm.spec.js
+++ b/test/components/AccountLoginForm.spec.js
@@ -1,0 +1,20 @@
+/* eslint-env jest */
+
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { tMock } from '../jestLib/I18n'
+import { AccountLoginForm } from '../../src/components/AccountLoginForm'
+
+describe('AccountLoginForm component', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('should enable connection button for valid OAuth account', () => {
+    const component = shallow(
+      <AccountLoginForm t={tMock} submit={jest.fn()} isOAuth />
+    ).node
+    expect(component).toMatchSnapshot()
+  })
+})

--- a/test/components/__snapshots__/AccountLoginForm.spec.js.snap
+++ b/test/components/__snapshots__/AccountLoginForm.spec.js.snap
@@ -1,0 +1,16 @@
+exports[`AccountLoginForm component should enable connection button for valid OAuth account 1`] = `
+<div
+  className="account-form-login"
+  role="form">
+  <div
+    className="coz-form-controls">
+    <button
+      aria-busy="false"
+      className="coz-btn coz-btn--regular coz-btn"
+      disabled={false}
+      onClick={[Function]}>
+      Connect
+    </button>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Error was due to https://github.com/cozy/cozy-collect/commit/21d661f#diff-4d5e78ed80ff9b0c288e11a2d8e4505aR78
I tried to set up some kind of tests for `statefulForm` but I did not succeed.