### PR TITLE
Dirty fix to handle auto-closing OAuth popup

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -52,6 +52,9 @@ const handleOAuthResponse = () => {
 
 // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
 function runKonnectorFromAccountId(accountId, client, store) {
+  document.querySelector(
+    '[role=application]'
+  ).innerHTML = `<h2>Récupération des données en cours, cela peut prendre quelques minutes ...</h2>`
   let account
   return client
     .fetchDocument('io.cozy.accounts', accountId)
@@ -92,13 +95,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
   if (oauthRedirectParams) {
-    return runKonnectorFromAccountId(
-      oauthRedirectParams.account,
-      client,
-      store
-    ).then(account => {
-      document.location = `/#/providers/all/${account.account_type}`
-    })
+    return runKonnectorFromAccountId(oauthRedirectParams.account, client, store)
+      .then(account => {
+        document.location = `/#/providers/all/${account.account_type}`
+      })
+      .catch(err => {
+        document.querySelector(
+          '[role=application]'
+        ).innerHTML = `<div><h2>Error: ${err.msg}</h2><div><a href='/'><button>"ok"</button></a></div><pre>stack trace:\n${err.stack}</pre></div>`
+      })
   }
 
   let history = hashHistory

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,7 +26,7 @@ const handleOAuthResponse = () => {
   const queryParams = new URLSearchParams(window.location.search)
   if (queryParams.get('account')) {
     const opener = window.opener
-    
+
     // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
     if (opener == null) {
       return { account: queryParams.get('account') }
@@ -53,7 +53,8 @@ const handleOAuthResponse = () => {
 // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
 function runKonnectorFromAccountId(accountId, client, store) {
   let account
-  return client.fetchDocument('io.cozy.accounts', accountId)
+  return client
+    .fetchDocument('io.cozy.accounts', accountId)
     .then(accounts => {
       account = accounts.data[0]
       return store.fetchKonnectorInfos(account.account_type)
@@ -88,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
     ...collectConfig,
     debug: __DEBUG__
   })
-   
+
   // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
   if (oauthRedirectParams) {
     return runKonnectorFromAccountId(
@@ -99,7 +100,7 @@ document.addEventListener('DOMContentLoaded', () => {
       document.location = `/#/providers/all/${account.account_type}`
     })
   }
-  
+
   let history = hashHistory
 
   if (shouldEnableTracking() && getTracker()) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -26,6 +26,12 @@ const handleOAuthResponse = () => {
   const queryParams = new URLSearchParams(window.location.search)
   if (queryParams.get('account')) {
     const opener = window.opener
+    
+    // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
+    if (opener == null) {
+      return { account: queryParams.get('account') }
+    }
+
     const accountKey = queryParams.get('account')
     const targetOrigin =
       window.location.origin ||
@@ -44,8 +50,22 @@ const handleOAuthResponse = () => {
   }
 }
 
+// TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
+function runKonnectorFromAccountId(accountId, client, store) {
+  let account
+  return client.fetchDocument('io.cozy.accounts', accountId)
+    .then(accounts => {
+      account = accounts.data[0]
+      return store.fetchKonnectorInfos(account.account_type)
+    })
+    .then(konnector => {
+      return store.runAccount(konnector, account, true, 0)
+    })
+    .then(() => account)
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  handleOAuthResponse()
+  const oauthRedirectParams = handleOAuthResponse()
 
   const root = document.querySelector('[role=application]')
   const data = root.dataset
@@ -68,7 +88,18 @@ document.addEventListener('DOMContentLoaded', () => {
     ...collectConfig,
     debug: __DEBUG__
   })
-
+   
+  // TODO : this is a hack. Why not remove this and add a route "redirect" with accountId ?
+  if (oauthRedirectParams) {
+    return runKonnectorFromAccountId(
+      oauthRedirectParams.account,
+      client,
+      store
+    ).then(account => {
+      document.location = `/#/providers/all/${account.account_type}`
+    })
+  }
+  
   let history = hashHistory
 
   if (shouldEnableTracking() && getTracker()) {


### PR DESCRIPTION
The authentication popup of Enedis Connect API as an auto-close script, which break the mechanisms of cozy-collect on OAuth authenticate dance. This patch allows cozy-collect to react when the stack redirect on ̀collect[...]/?account=[accountId]` ; and make cozy-collect a bit more restfull on this feature.

With a few more tests, it could be a temporary solution for this case ; )

ping @poupotte 