### PR TITLE
feat: clean statefulForm

### DIFF
--- a/docs/connector-configuration.md
+++ b/docs/connector-configuration.md
@@ -110,9 +110,9 @@ You can use `simple input`, or `advanced fields`. Single input will render class
 
 ### Input properties
 
-> __⚠️ To know:__ `dropdown` type will render a `<select>`, `folder` type is related to a complex input
+> __⚠️ To know:__ `dropdown` type will render a `<select>`
 
-* __type (required)__: text, password, hidden, checkbox, date, dropdown, folder
+* __type (required)__: text, password, hidden, checkbox, date, dropdown
 * __isRequired__: default = true, make the field required to validate the form
 * __pattern__: allow you to use a regex to validate a field
 * __min__: to define a minimum length of the value (number of characters)

--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -2,15 +2,13 @@ import styles from '../styles/accountLoginForm'
 
 import React from 'react'
 import classNames from 'classnames'
-import statefulForm from '../lib/statefulForm'
 import { translate } from 'cozy-ui/react/I18n'
 import Field, {
   PasswordField,
   DropdownField,
   CheckboxField,
   isHidden,
-  isAdvanced,
-  FolderPickerField
+  isAdvanced
 } from './Field'
 import ReactMarkdownWrapper from './ReactMarkdownWrapper'
 import { map, groupBy } from 'lodash'
@@ -21,10 +19,7 @@ const renderers = {
   checkbox: () => <CheckboxField />,
   dropdown: () => <DropdownField />,
   text: () => <Field />,
-  email: () => <Field type="email" />,
-  folder: ({ disableFolderPath }) => (
-    <FolderPickerField disabled={disableFolderPath} />
-  )
+  email: () => <Field type="email" />
 }
 
 const hydrateFieldValue = {
@@ -41,18 +36,16 @@ export const AccountLoginForm = props => {
     fields,
     error,
     dirty,
+    editing,
     isValid,
     allRequiredFieldsAreFilled,
     submitting,
-    forceDisabled,
     forceEnabled,
     values,
-    submit,
+    onSubmit,
     connectorSlug,
-    konnectorName,
     isSuccess,
     disableSuccessTimeout,
-    disableFolderPath,
     isUnloading,
     displayAdvanced,
     toggleAdvanced
@@ -81,7 +74,7 @@ export const AccountLoginForm = props => {
     !isSuccess &&
     !submitting &&
     submitEnabled
-  const onEnterKey = canHandleEnterKey && submit
+  const onEnterKey = canHandleEnterKey && onSubmit
 
   const renderField = field => {
     const { name, label, type, value, placeholder } = field
@@ -92,15 +85,13 @@ export const AccountLoginForm = props => {
 
     let fieldPlaceholder = null
     switch (name) {
-      case 'pathName':
-        fieldPlaceholder = konnectorName
-        break
       case 'password':
         fieldPlaceholder = t('account.form.placeholder.password')
         break
       default:
         fieldPlaceholder = placeholder || null
     }
+
     // Give focus only once
     const giveFocus = !alreadyFocused && !disabled
     if (giveFocus) alreadyFocused = giveFocus
@@ -143,8 +134,8 @@ export const AccountLoginForm = props => {
             {editableFields.map(renderField)}
           </fieldset>
         )}
-      {!displayAdvanced &&
-        !disableFolderPath &&
+      {!editing &&
+        !displayAdvanced &&
         !!advancedFields.length && (
           <button
             type="button"
@@ -155,7 +146,8 @@ export const AccountLoginForm = props => {
           </button>
         )}
 
-      {displayAdvanced &&
+      {!editing &&
+        displayAdvanced &&
         !!advancedFields &&
         !!advancedFields.length && (
           <fieldset className={styles['account-form-fieldset']}>
@@ -173,7 +165,7 @@ export const AccountLoginForm = props => {
                 'coz-btn--regular',
                 styles['coz-btn']
               )}
-              disabled={forceDisabled || submitting || !submitEnabled}
+              disabled={oAuthTerminated || submitting || !submitEnabled}
               aria-busy={
                 submitting &&
                 !disableSuccessTimeout &&
@@ -181,7 +173,7 @@ export const AccountLoginForm = props => {
                   ? 'true'
                   : 'false'
               }
-              onClick={submit}
+              onClick={onSubmit}
             >
               {t(
                 isUpdate
@@ -195,4 +187,4 @@ export const AccountLoginForm = props => {
   )
 }
 
-export default statefulForm()(translate()(AccountLoginForm))
+export default translate()(AccountLoginForm)

--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -58,6 +58,7 @@ export const KonnectorEdit = ({
   error,
   fields,
   folderPath,
+  editing,
   isUnloading,
   lastExecution,
   oAuthTerminated,
@@ -81,7 +82,6 @@ export const KonnectorEdit = ({
   // assign accountName placeholder
   if (fields.accountName)
     fields.accountName.placeholder = getAccountName(account)
-
   if (account && account.oauth)
     account.auth = Object.assign({}, account.auth, account.oauth)
 
@@ -115,14 +115,17 @@ export const KonnectorEdit = ({
               submitting={submitting}
               onForceConnection={onForceConnection}
             />
-            {folderPath && (
-              <KonnectorFolder
-                connector={connector}
-                account={account}
-                driveUrl={driveUrl}
-                fields={fields}
-              />
-            )}
+            {account &&
+              account.auth.folderPath &&
+              trigger.message.folder_to_save && (
+                <KonnectorFolder
+                  connector={connector}
+                  account={account}
+                  driveUrl={driveUrl}
+                  fields={fields}
+                  trigger={trigger}
+                />
+              )}
           </TabPanel>
 
           <TabPanel
@@ -146,13 +149,13 @@ export const KonnectorEdit = ({
                 disableSuccessTimeout={disableSuccessTimeout}
                 error={hasLoginError}
                 fields={fields}
+                editing={editing}
                 forceEnabled={!!error}
                 isOAuth={connector.oauth}
                 isUnloading={isUnloading}
                 oAuthTerminated={oAuthTerminated}
                 onSubmit={onSubmit}
                 submitting={submitting}
-                values={account ? account.auth : {}}
                 disableFolderPath
               />
             }

--- a/src/components/KonnectorFolder.jsx
+++ b/src/components/KonnectorFolder.jsx
@@ -10,16 +10,7 @@ import Field, { FolderPickerField } from './Field'
 
 class KonnectorFolder extends React.Component {
   componentDidMount = () => {
-    const { account, fields } = this.props
-    // Split the actual folderPath account to get namePath & folderPath values
-    fields.folderPath.value = account.auth.folderPath.substring(
-      0,
-      account.auth.folderPath.lastIndexOf('/')
-    )
-    fields.namePath.value = account.auth.folderPath.substring(
-      account.auth.folderPath.lastIndexOf('/') + 1,
-      account.auth.folderPath.length
-    )
+    const { fields } = this.props
     this.setState({
       fields: fields,
       isModalOpen: false,
@@ -40,6 +31,7 @@ class KonnectorFolder extends React.Component {
 
   updateFolderPath = () => {
     const { connector, account } = this.props
+    const folderId = this.props.trigger.message.folder_to_save
     const { store } = this.context
     const { fields } = this.state
     this.setState({
@@ -50,7 +42,7 @@ class KonnectorFolder extends React.Component {
     const folderPath = fields.folderPath.value
 
     store
-      .updateFolderPath(connector, account, {
+      .updateFolderPath(connector, account, folderId, {
         namePath: namePath,
         folderPath: `${folderPath}/${namePath}`
       })
@@ -71,11 +63,11 @@ class KonnectorFolder extends React.Component {
   }
 
   closeModal = () => {
-    this.setState({ isModalOpen: false })
+    this.setState({ isModalOpen: false, folderUpdateStatus: null })
   }
 
   render(
-    { t, account, driveUrl, connector },
+    { t, account, driveUrl, connector, trigger },
     { fields, isModalOpen, isFetching, changeState, folderUpdateStatus }
   ) {
     return (
@@ -105,7 +97,7 @@ class KonnectorFolder extends React.Component {
                 {driveUrl && (
                   <a
                     className={styles['col-account-folder-link']}
-                    href={`${driveUrl}${account.folderId}`}
+                    href={`${driveUrl}${trigger.message.folder_to_save}`}
                   >
                     {t('account.folder.link')}
                   </a>
@@ -156,7 +148,7 @@ class KonnectorFolder extends React.Component {
                       ) : (
                         <Button
                           busy={isFetching}
-                          theme="highlight"
+                          theme="regular"
                           onClick={this.updateFolderPath}
                         >
                           {t('account.folder.changePath')}

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -18,18 +18,25 @@ export const KonnectorInstall = ({
   driveUrl,
   error,
   fields,
-  forceDisabled,
   isTimeout,
   isUnloading,
   oAuthTerminated,
   onCancel,
+  editing,
   onDelete,
   onSubmit,
+  submit,
   submitting,
   success,
   successMessage,
   successMessages,
-  trigger
+  trigger,
+  allRequiredFieldsAreFilled,
+  displayAdvanced,
+  toggleAdvanced,
+  isValid,
+  isSuccess,
+  dirty
 }) => {
   const securityIcon = require('../assets/icons/color/icon-cloud-lock.svg')
   const { hasDescriptions, editor } = connector
@@ -75,19 +82,26 @@ export const KonnectorInstall = ({
             disableSuccessTimeout={disableSuccessTimeout}
             error={error && error.message === ACCOUNT_ERRORS.LOGIN_FAILED}
             fields={fields}
+            editing={editing}
+            isValid={isValid}
+            dirty={dirty}
+            isSuccess={isSuccess}
             forceEnabled={!!error}
-            forceDisabled={forceDisabled}
             isOAuth={connector.oauth}
             isUnloading={isUnloading}
             oAuthTerminated={oAuthTerminated}
             onSubmit={onSubmit}
             submitting={submitting}
+            allRequiredFieldsAreFilled={allRequiredFieldsAreFilled}
+            displayAdvanced={displayAdvanced}
+            toggleAdvanced={toggleAdvanced}
           />
         )}
 
         {success && (
           <KonnectorSuccess
             connector={connector}
+            account={account}
             driveUrl={driveUrl}
             folderId={trigger && trigger.message.folder_to_save}
             isTimeout={isTimeout}

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -10,7 +10,7 @@ export const KonnectorSuccess = ({
   t,
   connector,
   isTimeout,
-  folderPath,
+  account,
   folderId,
   onCancel,
   driveUrl,
@@ -27,11 +27,9 @@ export const KonnectorSuccess = ({
                 name: connector.name
               })}
               <br />
-              {folderPath && (
-                <span
-                  className={styles['col-account-success-highlighted-data']}
-                >
-                  {folderPath}
+              {account.auth.folderPath && (
+                <span className={styles['col-account-folder-highlighted-data']}>
+                  {account.auth.folderPath}
                 </span>
               )}
               {driveUrl &&

--- a/src/config/advancedFields.js
+++ b/src/config/advancedFields.js
@@ -4,7 +4,7 @@ const advancedFields = {
       type: 'text'
     },
     folderPath: {
-      type: 'folder'
+      type: 'dropdown'
     }
   }
 }

--- a/src/lib/CollectStore.js
+++ b/src/lib/CollectStore.js
@@ -211,13 +211,7 @@ export default class CollectStore {
 
   // Account connection workflow, see
   // https://github.com/cozy/cozy-stack/blob/master/docs/konnectors_workflow_example.md
-  connectAccount(
-    konnector,
-    account,
-    folderPath,
-    disableEnqueue,
-    enqueueAfter = 7000
-  ) {
+  connectAccount(konnector, account, disableEnqueue, enqueueAfter = 7000) {
     const startTime = new Date().getTime()
 
     // return object to store all business object implied in the connection
@@ -235,7 +229,7 @@ export default class CollectStore {
 
     // 1. Create folder, will be replaced by an intent or something else
     return (
-      createDirectoryIfNecessary(folderPath)
+      createDirectoryIfNecessary(account.auth.folderPath)
         // 2. Create account
         .then(folder => {
           connection.folder = folder
@@ -261,8 +255,6 @@ export default class CollectStore {
         })
         // 3. Konnector installation
         .then(account => {
-          // this.dispatch(updateConnectionRunningStatus(konnector, account, true))
-
           connection.account = account
 
           return new Promise((resolve, reject) => {
@@ -271,7 +263,6 @@ export default class CollectStore {
 
             const enqueue = () => {
               clearTimeout(enqueueTimeout)
-              // this.dispatch(enqueueConnection(konnector, account))
               enqueued = true
               resolve(connection)
             }
@@ -409,10 +400,10 @@ export default class CollectStore {
       })
   }
 
-  updateFolderPath(connector, account, values, t) {
+  updateFolderPath(connector, account, folderId, values, t) {
     // Update file
     return cozy.client.files
-      .updateAttributesById(account.folderId, {
+      .updateAttributesById(folderId, {
         name: values.namePath,
         path: values.folderPath
       })

--- a/src/lib/statefulForm.jsx
+++ b/src/lib/statefulForm.jsx
@@ -17,11 +17,10 @@ export default function statefulForm(mapPropsToFormConfig) {
             t('account.form.placeholder.accountName')
           ),
           dirty: false,
-          submit: this.handleSubmit.bind(this),
           oauth: props.onOAuth,
           displayAdvanced: false,
           isValid: true,
-          allRequiredFieldsAreFilled: true
+          allRequiredFieldsAreFilled: false
         }
       }
 
@@ -92,16 +91,17 @@ export default function statefulForm(mapPropsToFormConfig) {
 
       configureFields(config, defaultAccountNamePlaceholder) {
         // it will at least have an accountName field
-        if (!config || !config.fields) config = { fields: {} }
-        const konnectorName = config.konnectorName
+        if (!config || !config.konnector.fields) config = { fields: {} }
+        const konnectorName = config.konnector.name
         const accountNamePlaceholder =
-          config.fields.accountName && config.fields.accountName.placeholder
+          config.konnector.fields.accountName &&
+          config.konnector.fields.accountName.placeholder
         const accountNameField = {
           type: 'text',
           isRequired: false,
           placeholder: accountNamePlaceholder || defaultAccountNamePlaceholder
         }
-        const fieldsFromConfig = Object.assign({}, config.fields, {
+        const fieldsFromConfig = Object.assign({}, config.konnector.fields, {
           accountName: accountNameField
         })
 
@@ -169,21 +169,7 @@ export default function statefulForm(mapPropsToFormConfig) {
         if (fields.calendar && !fields.calendar.default) {
           fields.calendar.default = konnectorName
         }
-        if (fields.namePath && fields.namePath.value === '')
-          fields.namePath.value = konnectorName
-        if (!fields.frequency) {
-          fields.frequency = {
-            type: 'text',
-            hidden: true,
-            isRequired: false
-          }
-        }
-        if (fields.frequency && !fields.frequency.default) {
-          fields.frequency.default = 'week'
-        }
 
-        // Update config.fields with builded fields.
-        config.fields = fields
         return fields
       }
 
@@ -287,14 +273,9 @@ export default function statefulForm(mapPropsToFormConfig) {
             unfilled.push(field)
         }
         this.setState({
-          allRequiredFieldsAreFilled: unfilled.length === 0
+          allRequiredFieldsAreFilled: unfilled.length === 0,
+          values: this.getData()
         })
-      }
-
-      handleSubmit() {
-        if (this.props.onSubmit && this.state.isValid) {
-          return this.props.onSubmit(this.getData())
-        }
       }
 
       getData() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,7 @@
       "link" : "Open the folder in Cozy Drive",
       "changePath": "change the path",
       "error": "Oops, something went wrong. Don't panic, your files are still there, please try again later",
-      "close": "fermer",
+      "close": "close",
       "warning": "You're changing your folder path",
       "oldFiles": "All your olds bills will be moved in your new path.",
       "newFiles": "Your news bills will be downloaded in your new path.",

--- a/test/components/AccountLoginForm.spec.js
+++ b/test/components/AccountLoginForm.spec.js
@@ -15,7 +15,7 @@ describe('AccountLoginForm component', () => {
     const component = shallow(
       <AccountLoginForm
         t={tMock}
-        submit={jest.fn()}
+        onSubmit={jest.fn()}
         isOAuth
         isValid
         allRequiredFieldsAreFilled

--- a/yarn.lock
+++ b/yarn.lock
@@ -1852,7 +1852,7 @@ cozy-client-js@^0.3.19:
   version "0.3.21"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
 
-cozy-client-js@^0.4.1:
+cozy-client-js@^0.4.5:
   version "0.4.5"
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.4.5.tgz#87b6e0837833961d4785ca82e8141725fecbd5ac"
   dependencies:


### PR DESCRIPTION
L'idée est de déplacer toute la logique formulaire dans AccountConnection / ConnectorManagement pour garder le même état partout, et alléger le statefulForm de code spécifique.

- Déplacer le `fetchFolders` dans `AccountConnetion`, pour éviter le `<select>` vide quand on affiche le champ de `folderPath`
- Passer le `statefulform` seulement dans `AccountConnection`, pour avoir le même form dans tous les composants enfants (Edit, Install, AccountLogin, etc), contre seulement dans `AccountLoginForm` précédement
- Préparer les values qu'on doit modifier avant de les injecter (`namePath` / `folderPath`) dans le composant parent du `statefulForm` (`ConnectorManagement`) pour que le statefulForm en hérite en props, et le garder le plus abstrait possible
- Suppression du champ `frequency` non utilisé
- Suppression du `submit` du statefulform, pour laisser `AccountConnection` le passer en props à ses enfants : il faisait référence à handleSubmit qui lui même renvoyé à props.onSubmit = le onSubmit du AccountConnection
- `type='folder'` devient `type='dropdown'`
- suppression de `forceDisabled`, pour utiliser `oAuthTerminated`, on avait un doublon avec `forceDisabled={oAuthTerminated}` passé en props
- suppression du code qui mutait le konnector.fields