### PR TITLE
[WIP] feat: get connectionStatus in ServiceKonnectorsList

### DIFF
--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -1,18 +1,46 @@
 import React from 'react'
 import { connect } from 'react-redux'
 
-import { getKonnectorConnectedAccount } from '../../ducks/connections'
+import {
+  getKonnectorConnectedAccount,
+  getTriggerByKonnector
+} from '../../reducers'
 
 import AccountConnection from '../../containers/AccountConnection'
 
 const CreateAccountService = props => {
-  const { existingAccount, konnector } = props
+  const { existingAccount, konnector, trigger, t } = props
+  console.log(props)
+  const values =
+    (existingAccount && Object.assign({}, existingAccount.auth)) || {}
+  // Split the actual folderPath account to get namePath & folderPath values
+  if (existingAccount && values.folderPath) {
+    values.folderPath = existingAccount.auth.folderPath.substring(
+      0,
+      existingAccount.auth.folderPath.lastIndexOf('/')
+    )
+    values.namePath = existingAccount.auth.folderPath.substring(
+      existingAccount.auth.folderPath.lastIndexOf('/') + 1,
+      existingAccount.auth.folderPath.length
+    )
+  } else if (
+    (existingAccount === null &&
+      konnector.fields &&
+      konnector.fields.advancedFields &&
+      konnector.fields.advancedFields.folderPath) ||
+    (existingAccount === null && konnector.fields && konnector.folderPath)
+  ) {
+    values.folderPath =
+      konnector.fields.advancedFields.folderPath.default ||
+      t('account.config.default_folder')
+    values.namePath = konnector.name
+  }
   return (
     <div className="coz-service-content">
       <AccountConnection
         connector={konnector}
-        existingAccount={existingAccount}
-        fields={konnector.fields}
+        trigger={trigger}
+        values={values}
         {...props}
       />
     </div>
@@ -21,10 +49,8 @@ const CreateAccountService = props => {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    existingAccount: getKonnectorConnectedAccount(
-      state.cozy,
-      ownProps.konnector
-    )
+    existingAccount: getKonnectorConnectedAccount(state, ownProps.konnector),
+    trigger: getTriggerByKonnector(state, ownProps.konnector)
   }
 }
 

--- a/src/components/services/ServiceKonnectorsList.jsx
+++ b/src/components/services/ServiceKonnectorsList.jsx
@@ -1,35 +1,47 @@
 import styles from '../../styles/konnectorItem'
 
 import React from 'react'
+import { connect } from 'react-redux'
 
 import { translate } from 'cozy-ui/react/I18n'
 
+import { getConnectionsStatusesByKonnectors } from '../../ducks/connections'
 import { getKonnectorIcon } from '../../lib/icons'
 import { CONNECTION_STATUS } from '../../lib/CollectStore'
 
-const ServiceKonnectorsList = ({ t, konnectorsList, showKonnector }) => (
+const ServiceKonnectorsList = ({
+  konnectorsList,
+  showKonnector,
+  t,
+  connectionStatuses
+}) => (
   <ul className="connector-list">
-    {konnectorsList.map(konnector => (
-      <li
-        onKeyDown={e => (e.keyCode === 13 ? showKonnector(konnector) : null)}
-        onClick={() => showKonnector(konnector)}
-        tabIndex="0"
-        className="item-wrapper"
-      >
-        <header className="item-header">
-          <img
-            className="item-icon"
-            alt={t('connector.logo.alt', { name })}
-            src={getKonnectorIcon(konnector)}
-          />
-        </header>
-        <p className="item-title">{konnector.name}</p>
-        {konnector.category && (
-          <p className="item-subtitle">{t(`category.${konnector.category}`)}</p>
-        )}
-        {konnector.status && stateIcon(konnector.status)}
-      </li>
-    ))}
+    {konnectorsList.map(konnector => {
+      return (
+        <li
+          onKeyDown={e => (e.keyCode === 13 ? showKonnector(konnector) : null)}
+          onClick={() => showKonnector(konnector)}
+          tabIndex="0"
+          className="item-wrapper"
+        >
+          <header className="item-header">
+            <img
+              className="item-icon"
+              alt={t('connector.logo.alt', { name })}
+              src={getKonnectorIcon(konnector)}
+            />
+          </header>
+          <p className="item-title">{konnector.name}</p>
+          {konnector.category && (
+            <p className="item-subtitle">
+              {t(`category.${konnector.category}`)}
+            </p>
+          )}
+          {connectionStatuses[konnector.slug] &&
+            stateIcon(connectionStatuses[konnector.slug])}
+        </li>
+      )
+    })}
   </ul>
 )
 
@@ -52,4 +64,14 @@ const stateIcon = status => {
   }
 }
 
-export default translate()(ServiceKonnectorsList)
+const mapStateToProps = (state, ownProps) => ({
+  connectionStatuses:
+    (ownProps.konnectorsList &&
+      getConnectionsStatusesByKonnectors(
+        state,
+        ownProps.konnectorsList.map(konnector => konnector)
+      )) ||
+    []
+})
+
+export default connect(mapStateToProps)(translate()(ServiceKonnectorsList))

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -4,7 +4,7 @@ import { getTriggerLastJob } from '../jobs'
 import { getKonnectorAccount } from './konnector'
 
 import { deleteTrigger, launchTrigger } from '../triggers'
-import { deleteAccount, getAccount } from '../accounts'
+import { deleteAccount, getAccount, getIds } from '../accounts'
 
 // constant
 const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
@@ -225,17 +225,6 @@ export const updateConnectionError = (konnector, account, error) => ({
   error
 })
 
-// export const updateConnectionRunningStatus = (
-//   konnector,
-//   account,
-//   isRunning = false
-// ) => ({
-//   type: UPDATE_CONNECTION_RUNNING_STATUS,
-//   konnector,
-//   account,
-//   isRunning
-// })
-
 // action creators async
 export const deleteConnection = trigger => {
   return (dispatch, getState) => {
@@ -279,7 +268,12 @@ export const getConnectionStatus = (
   existingAccountIds = []
 ) => {
   // Sould we access `state.connections` from here ?
-  const triggers = state[konnector.slug] && state[konnector.slug].triggers
+  const triggers =
+    state.connections &&
+    state.connections[konnector.slug] &&
+    state.connections[konnector.slug].triggers
+
+  existingAccountIds = getIds(state.cozy)
 
   if (!triggers) return null
 
@@ -359,10 +353,15 @@ export const getTriggerLastExecution = (state, trigger) => {
   )
 }
 
-export const getConnectionsStatusesByKonnectors = (state, konnectorSlugs) =>
-  konnectorSlugs.map(slug => {
-    return getConnectionStatus(state, slug)
-  })
+export const getConnectionsStatusesByKonnectors = (state, konnectors) => {
+  let connectionsStatusesByKonnectors = {}
+  for (let konnector in konnectors) {
+    connectionsStatusesByKonnectors[
+      konnectors[konnector]['slug']
+    ] = getConnectionStatus(state, konnectors[konnector])
+  }
+  return connectionsStatusesByKonnectors
+}
 
 // get trigger from state, in state[konnectorSlug].triggers[triggerId]
 const getTriggerState = (state, trigger) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5928,9 +5928,9 @@ pouchdb-abstract-mapreduce@6.3.4:
     pouchdb-promise "6.3.4"
     pouchdb-utils "6.3.4"
 
-"pouchdb-adapter-cordova-sqlite@git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
+"pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"
-  resolved "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
+  resolved "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
   dependencies:
     pouchdb-adapter-websql-core "^6.1.1"
 


### PR DESCRIPTION
- Récupére et assigne le status d'un konnector dans `ServiceKonnectorsList` plutôt que dans `IntentService` qui n'a pas `konnectorsList` en props

TODO :
- Réparer `existingAccount` pour afficher correctement un connecteur