### PR TITLE
feat: improve folder path modifications

### DIFF
--- a/docs/connector-configuration.md
+++ b/docs/connector-configuration.md
@@ -120,6 +120,7 @@ You can use `simple input`, or `advanced fields`. Single input will render class
 * __advanced__: default false, add the field on the "advenced options" fieldset
 * __hasDescription__: see `Field description` section of this documentation
 * __options__: related to dropdown, define the options of the `<select>`
+* __default__: default value for the fields. It can a string for a text field, or an obect for a select field ("default": {"value": "foo","name": "bar"},)
 
 ### Advanced fieldsets
 

--- a/src/components/Field.jsx
+++ b/src/components/Field.jsx
@@ -183,57 +183,16 @@ export const DropdownField = translate()(props => {
       >
         {dropdownFieldOptions.map(optionValue => (
           <option
-            value={optionValue.value}
+            value={optionValue.value || (props.default && props.default.value)}
             selected={optionValue.value === { value }}
           >
-            {optionValue.name}
+            {optionValue.name || (props.default && props.default.name)}
           </option>
         ))}
       </select>
     </FieldWrapper>
   )
 })
-
-class FolderPickerFieldComponent extends Component {
-  constructor(props, context) {
-    super(props)
-    this.store = context.store
-    this.state = { isFetching: true, foldersList: [{ path: props.value }] }
-    this.store.fetchFolders().then(folders => {
-      const foldersList = folders.find(f => f.path === props.value)
-        ? folders
-        : [{ path: props.value }].concat(folders)
-      this.setState({
-        isFetching: false,
-        foldersList
-      })
-    })
-  }
-
-  render() {
-    const { value, onChange, onInput, disabled } = this.props
-    const { isFetching, foldersList } = this.state
-    return (
-      <FieldWrapper {...this.props}>
-        <select
-          className={styles['coz-field-dropdown']}
-          value={isFetching ? 'loading' : value}
-          onChange={onChange}
-          onInput={onInput}
-          aria-busy={isFetching}
-          disabled={disabled || isFetching}
-        >
-          {foldersList.map(folder => (
-            <option value={folder.path} selected={folder.path === value}>
-              {folder.path}
-            </option>
-          ))}
-        </select>
-      </FieldWrapper>
-    )
-  }
-}
-export const FolderPickerField = translate()(FolderPickerFieldComponent)
 
 export const CheckboxField = translate()(props => {
   const { value, onChange, onInput, label, errors } = props

--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -62,6 +62,8 @@ export const KonnectorEdit = ({
   isUnloading,
   lastExecution,
   oAuthTerminated,
+  folders,
+  closeModal,
   onCancel,
   onDelete,
   onForceConnection,
@@ -124,6 +126,8 @@ export const KonnectorEdit = ({
                   driveUrl={driveUrl}
                   fields={fields}
                   trigger={trigger}
+                  folders={folders}
+                  closeModal={closeModal}
                 />
               )}
           </TabPanel>

--- a/src/components/KonnectorFolder.jsx
+++ b/src/components/KonnectorFolder.jsx
@@ -6,7 +6,7 @@ import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import styles from '../styles/konnectorFolder'
 
 import DescriptionContent from './DescriptionContent'
-import Field, { FolderPickerField } from './Field'
+import Field, { DropdownField } from './Field'
 
 class KonnectorFolder extends React.Component {
   componentDidMount = () => {
@@ -30,7 +30,7 @@ class KonnectorFolder extends React.Component {
   }
 
   updateFolderPath = () => {
-    const { connector, account } = this.props
+    const { connector, account, folders } = this.props
     const folderId = this.props.trigger.message.folder_to_save
     const { store } = this.context
     const { fields } = this.state
@@ -40,11 +40,14 @@ class KonnectorFolder extends React.Component {
 
     const namePath = fields.namePath.value
     const folderPath = fields.folderPath.value
+    const fullFolderPath = `${fields.folderPath.value}/${fields.namePath.value}`
+    const dirId = folders.find(folder => folder.path === folderPath)._id
 
     store
       .updateFolderPath(connector, account, folderId, {
         namePath: namePath,
-        folderPath: `${folderPath}/${namePath}`
+        folderPath: fullFolderPath,
+        dir_id: dirId
       })
       .then(() => {
         this.setState({
@@ -67,7 +70,7 @@ class KonnectorFolder extends React.Component {
   }
 
   render(
-    { t, account, driveUrl, connector, trigger },
+    { t, account, driveUrl, connector, trigger, closeModal },
     { fields, isModalOpen, isFetching, changeState, folderUpdateStatus }
   ) {
     return (
@@ -82,7 +85,7 @@ class KonnectorFolder extends React.Component {
                       label={t('account.form.label.namePath')}
                       {...fields.namePath}
                     />
-                    <FolderPickerField
+                    <DropdownField
                       label={t('account.form.label.folderPath')}
                       {...fields.folderPath}
                     />
@@ -105,7 +108,7 @@ class KonnectorFolder extends React.Component {
               </p>
               {isModalOpen && (
                 <Modal
-                  secondaryAction={this.closeModal}
+                  secondaryAction={() => closeModal()}
                   title={t('account.folder.warning')}
                   className={styles['col-account-folder-modal-path']}
                 >
@@ -142,7 +145,7 @@ class KonnectorFolder extends React.Component {
 
                     <p className={styles['col-account-folder-modal-path-btn']}>
                       {folderUpdateStatus ? (
-                        <Button theme="secondary" onClick={this.closeModal}>
+                        <Button theme="secondary" onClick={() => closeModal()}>
                           {t('account.folder.close')}
                         </Button>
                       ) : (

--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -736,7 +736,7 @@
       }
     },
     "additionnalSuccessMessage": {
-      "message": "connector.debug.successMessage" 
+      "message": "connector.debug.successMessage"
     },
     "source": "git://github.com/cozy/cozy-konnector-debug.git#build"
   },

--- a/src/containers/ConnectorManagement.jsx
+++ b/src/containers/ConnectorManagement.jsx
@@ -37,10 +37,7 @@ class ConnectorManagement extends Component {
         0,
         props.existingAccount.auth.folderPath.lastIndexOf('/')
       )
-      values.namePath = props.existingAccount.auth.folderPath.substring(
-        props.existingAccount.auth.folderPath.lastIndexOf('/') + 1,
-        props.existingAccount.auth.folderPath.length
-      )
+      values.namePath = props.existingAccount.auth.namePath
     } else if (
       (props.existingAccount === null &&
         props.konnector.fields &&
@@ -84,6 +81,7 @@ class ConnectorManagement extends Component {
               onCancel={() => this.gotoParent()}
               isUnloading={isClosing}
               values={values}
+              closeModal={() => this.gotoParent()}
               {...this.state}
               {...this.props}
               {...this.context}


### PR DESCRIPTION
- Ajout du déplacement d'un dossier
- Suppression du `FolderPickerField` devenu inutile
- Suppression de la variable `foldersFromStack` qui gardaie en cache la liste des dossiers, empêchant de la fetcher à nouveau après l'installation / la modification d'un connecteur
- Fermeture de la modal de connecteur une fois le dossier modifié, au lieu de revenir sur l'onglet de modification
