### PR TITLE
fix: ensure consistency between displayed konnector and redux registry 🚑

### DIFF
--- a/src/components/CategoryList.jsx
+++ b/src/components/CategoryList.jsx
@@ -1,6 +1,11 @@
 import React from 'react'
+
+import { connect } from 'react-redux'
+
 import { translate } from 'cozy-ui/react/I18n'
 import KonnectorList from './KonnectorList'
+
+import { getRegistryKonnectorsByCategory } from '../ducks/registry'
 
 const CategoryList = ({ t, category, categories, connectors, children }) => (
   <div className="content">
@@ -16,4 +21,14 @@ const CategoryList = ({ t, category, categories, connectors, children }) => (
   </div>
 )
 
-export default translate()(CategoryList)
+const mapStateToProps = (state, ownProps) => {
+  const { filter } = ownProps.params
+  return {
+    connectors: getRegistryKonnectorsByCategory(
+      state.registry,
+      filter !== 'all' && filter
+    )
+  }
+}
+
+export default connect(mapStateToProps)(translate()(CategoryList))

--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -24,7 +24,15 @@ const reducer = (state = {}, action) => {
 export default reducer
 
 // selectors
-export const getRegistryKonnectors = state => state.konnectors
+export const getRegistryKonnectors = state =>
+  Object.values(state.konnectors.data) || []
+
+export const getRegistryKonnectorsByCategory = (state, category) =>
+  category
+    ? Object.values(state.konnectors.data).filter(
+        konnector => konnector.category === category
+      )
+    : getRegistryKonnectors(state)
 
 export const getRegistryKonnectorsFromSlugs = (state, slugs = []) => {
   return slugs.reduce((returnedKonnectors, slug) => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -116,12 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
             <Route
               path="/providers/:filter"
               component={props => (
-                <CategoryList
-                  category={props.params.filter}
-                  categories={store.categories}
-                  connectors={store.findByCategory(props.params.filter)}
-                  {...props}
-                />
+                <CategoryList {...props} categories={store.categories} />
               )}
             >
               <Route


### PR DESCRIPTION
Konnector list was not consistent between displayed list an redux registry.

I connected `<CategoryList />` to redux.