### PR TITLE
feat: delete 'banque postale' connector

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -930,30 +930,6 @@
     }
   },
   {
-    "slug": "labanquepostale175",
-    "name": "Banque Postale (Particuliers)",
-    "editor": "Cozy Cloud",
-    "vendorLink": "https://www.labanquepostale.fr",
-    "category": "banking",
-    "icon": "labanquepostale.png",
-    "dataType": [
-      "bankAccounts",
-      "bankTransactions"
-    ],
-    "fields": {
-      "identifier": {
-        "type": "text"
-      },
-      "secret": {
-        "type": "password"
-      }
-    },
-    "source": "git+ssh://git@gitlab.cozycloud.cc/labs/cozy-konnector-linxo.git#build",
-    "parameters": {
-      "bankId": "175"
-    }
-  },
-  {
     "slug": "labanquepostale44",
     "name": "La Banque Postale (Particuliers)",
     "editor": "Cozy Cloud",


### PR DESCRIPTION
Delete the connector "banque postale" since it was a duplicate with "la banque postale". We only keep "la banque postale" since it is the complete name of this bank.