### PR TITLE
✨ feat: support float in timeInterval

### DIFF
--- a/src/lib/daytime.js
+++ b/src/lib/daytime.js
@@ -5,7 +5,7 @@
 // @returns an object with two atributes : hours and minutes
 export const randomDayTime = (
   interval = [0, 1],
-  randomize = (min, max) => Math.floor(Math.random() * (max - min) + min)
+  randomize = (min, max) => Math.random() * (max - min) + min
 ) => {
   if (!interval) throw new Error('Missing interval parameter')
   if (!randomize) throw new Error('Missing randomize parameter')
@@ -19,8 +19,9 @@ export const randomDayTime = (
 
   if (start < 0 || end > 24) throw new Error('interval must be inside [0, 24]')
 
-  let hours = randomize(start, end)
-  let minutes = randomize(0, 60)
+  const r = randomize(start, end)
+  const hours = Math.floor(r)
+  const minutes = Math.floor((r - hours) * 60)
 
   if (hours < 0 || hours > 23)
     throw new Error('randomize function returns inconsistent hour value')

--- a/test/lib/__snapshots__/daytime.spec.js.snap
+++ b/test/lib/__snapshots__/daytime.spec.js.snap
@@ -13,10 +13,6 @@ exports[`daytime library randomDayTime throws error on inconsistent start hour 1
 
 exports[`daytime library randomDayTime throws error on incorrect maximal hour 1`] = `"randomize function returns inconsistent hour value"`;
 
-exports[`daytime library randomDayTime throws error on incorrect maximal minute 1`] = `"randomize function returns inconsistent minute value"`;
-
-exports[`daytime library randomDayTime throws error on incorrect minimal minute 1`] = `"randomize function returns inconsistent minute value"`;
-
 exports[`daytime library randomDayTime throws error when interval is malformed 1`] = `"interval must contain two values"`;
 
 exports[`daytime library randomDayTime throws error when interval is not an array 1`] = `"interval must be an array"`;

--- a/test/lib/daytime.spec.js
+++ b/test/lib/daytime.spec.js
@@ -32,10 +32,7 @@ describe('daytime library', () => {
     })
 
     it('returns expected hours/minutes values', () => {
-      const randomizeStub = jest
-        .fn()
-        .mockReturnValueOnce(10)
-        .mockReturnValueOnce(34)
+      const randomizeStub = jest.fn().mockReturnValueOnce(10.58)
 
       const result = randomDayTime([0, 24], randomizeStub)
 
@@ -58,28 +55,6 @@ describe('daytime library', () => {
         .fn()
         .mockReturnValueOnce(24)
         .mockReturnValueOnce(34)
-
-      expect(() =>
-        randomDayTime([0, 24], randomizeStub)
-      ).toThrowErrorMatchingSnapshot()
-    })
-
-    it('throws error on incorrect minimal minute', () => {
-      const randomizeStub = jest
-        .fn()
-        .mockReturnValueOnce(12)
-        .mockReturnValueOnce(-1)
-
-      expect(() =>
-        randomDayTime([0, 24], randomizeStub)
-      ).toThrowErrorMatchingSnapshot()
-    })
-
-    it('throws error on incorrect maximal minute', () => {
-      const randomizeStub = jest
-        .fn()
-        .mockReturnValueOnce(12)
-        .mockReturnValueOnce(-1)
 
       expect(() =>
         randomDayTime([0, 24], randomizeStub)


### PR DESCRIPTION
Supports [6.5, 7.5] as timeInterval, meaning between 6:30AM and 7:30AM.

Previously, minutes were all across the clocks (`randomize(0, 60)`) so if you put [6.5, 7.5], you could get 6:15AM or 7:57AM.