### PR TITLE
fix: componentDidUpdate was buggy on connections queue

### DIFF
--- a/src/ducks/connections/components/queue/queue.jsx
+++ b/src/ducks/connections/components/queue/queue.jsx
@@ -24,8 +24,10 @@ class Item extends Component {
       })
     }, 25)
   }
-  componentDidUpdate = prevProps => {
-    if (prevProps.status !== this.props.status) {
+  componentDidUpdate = () => {
+    // If the status of the konnector is not 'ongoing', we remove the progressBar
+    const updatedStatus = this.props.status
+    if (updatedStatus !== 'ongoing') {
       clearInterval(this.myInterval)
       this.progressBar.remove()
     }


### PR DESCRIPTION
Depuis le passage à Redux, le state de la file d'attente est dépendant du store, donc il est mis à jour plus régulièrement. 

Là où le composant était "figé" une fois monté, il reçoit maintenant des nouvelles props à chaque changement du store.

La méthode componentDidUpdate "historique" n'est donc plus correcte pour masquer la file d'attente.