### PR TITLE
feat: filter konnectors categories based on context ✨

### DIFF
--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -83,15 +83,25 @@ export const initializeRegistry = konnectors => {
       .then(context => {
         const konnectorsToExclude =
           !!context.attributes && context.attributes.exclude_konnectors
+        const filteredKonnectors =
+          context.attributes && context.attributes.debug
+            ? konnectors
+            : konnectors.filter(
+                k => !k.categories.includes('banking') && k.slug !== 'debug'
+              )
+
         if (konnectorsToExclude && konnectorsToExclude.length) {
           return dispatch({
             type: FETCH_REGISTRY_KONNECTORS_SUCCESS,
-            konnectors: konnectors.filter(
+            konnectors: filteredKonnectors.filter(
               k => !konnectorsToExclude.includes(k.slug)
             )
           })
         }
-        return dispatch({ type: FETCH_REGISTRY_KONNECTORS_SUCCESS, konnectors })
+        return dispatch({
+          type: FETCH_REGISTRY_KONNECTORS_SUCCESS,
+          konnectors: filteredKonnectors
+        })
       })
       .catch(() => {
         dispatch({ type: FETCH_REGISTRY_KONNECTORS_ERROR, konnectors: [] })


### PR DESCRIPTION
Context can now have a `debug` property. When set to `true`,  it shows Debug konnector and Banking konnectors.