### PR TITLE
fix: remove "Nobody will access it!" for banking account

### DIFF
--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -86,7 +86,9 @@ export const KonnectorInstall = ({
               <svg>
                 <use xlinkHref={securityIcon} />
               </svg>
-              {t('account.config.security')}
+              {connector.categories && connector.categories.includes('banking')
+                ? t('account.config.security_third_party')
+                : t('account.config.security')}
             </p>
           )}
         </DescriptionContent>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,6 +12,7 @@
       "optional": "(optional)",
       "title": "Connect your %{name} account to your Cozy",
       "security": "Your login and password will be stored in your Cozy. Nobody will access it!",
+      "security_third_party": "Your login and password will be stored in your Cozy.",
       "connected_title": "You already have account(s) for this provider:",
       "connected_link": "Access my connected accounts",
       "data": {


### PR DESCRIPTION
Banking konnector use Linxo as a third party, so we can't say "Nobody will access it!"