### PR TITLE
Remove max constraint on Malakoff Mederic password

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1419,8 +1419,7 @@
       },
       "password": {
         "type": "password",
-        "min": 4,
-        "max": 15
+        "min": 4
       },
       "advancedFields": {
         "folderPath": {


### PR DESCRIPTION
Remove max constraint on Malakoff Mederic password.

The password length seems to be incorrect. It's fixed at 15 characters but it can actually be longer (mine is 128).