### PR TITLE
feat: sanitize konnectors categories ✨

### DIFF
--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -10,16 +10,13 @@ const FETCH_REGISTRY_KONNECTORS_SUCCESS = 'FETCH_REGISTRY_KONNECTORS_SUCCESS'
 
 export const OTHERS_CATEGORY = 'others'
 
-const getUncategorizedKonnectors = (list, categories) =>
-  list.reduce((uncategorized, konnector) => {
-    if (
+// helpers
+const getUncategorizedKonnectors = (konnectors, categories) =>
+  konnectors.filter(
+    konnector =>
       konnector.categories &&
       !konnector.categories.every(category => categories.includes(category))
-    ) {
-      uncategorized.push(konnector)
-    }
-    return uncategorized
-  }, [])
+  )
 
 // reducers
 

--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -14,12 +14,17 @@ export const OTHERS_CATEGORY = 'others'
 const getUncategorizedKonnectors = (konnectors, categories) =>
   konnectors.filter(
     konnector =>
-      konnector.categories &&
-      !konnector.categories.every(category => categories.includes(category))
+      !konnector.categories.length ||
+      (konnector.categories &&
+        !konnector.categories.every(category => categories.includes(category)))
   )
 
-// reducers
+const sanitizeKonnector = konnector => ({
+  categories: [],
+  ...konnector
+})
 
+// reducers
 const reducer = (state = {}, action) => {
   switch (action.type) {
     case FETCH_REGISTRY_KONNECTORS:
@@ -115,7 +120,7 @@ export const initializeRegistry = konnectors => {
         }
         return dispatch({
           type: FETCH_REGISTRY_KONNECTORS_SUCCESS,
-          konnectors: filteredKonnectors
+          konnectors: filteredKonnectors.map(sanitizeKonnector)
         })
       })
       .catch(() => {


### PR DESCRIPTION
Sanitize konnectors from registry and ensure they all have a `categories` attribute.

Prevent missing or malformed `categories` attribute from manifest.