### PR TITLE
fix: add missing field for Barclays konnector

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -167,6 +167,9 @@
       "identifier": {
         "type": "text"
       },
+      "code": {
+        "type": "password"
+      },
       "secret": {
         "type": "password"
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,7 +59,8 @@
         "token": "Token",
         "agreement": "I agree",
         "refreshToken": "Refresh Token",
-        "branchName": "Branch"
+        "branchName": "Branch",
+        "code": "Confidential code"
       },
       "placeholder": {
         "password": "The password you use to connect to the service",


### PR DESCRIPTION
I forgot a field in #497. This fixes it. Sorry.

#### Checklist

Before merging this PR, the following things must have been done:

- [x] Localized in english and french