### PR TITLE
feat: add testing attribute for in konnectors.json ✨

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -156,6 +156,7 @@
     "name": "Barclays",
     "editor": "Cozy Cloud",
     "vendorLink": "https://www.barclays.fr/",
+    "testing": true,
     "categories": ["banking"],
     "partner": "Linxo",
     "icon": "barclays.svg",
@@ -823,6 +824,7 @@
     "name": "Crédit Agricole by Cozy",
     "editor": "Cozy Cloud",
     "vendorLink": "https://www.credit-agricole.fr",
+    "testing": true,
     "categories": ["banking"],
     "partner": "Linxo",
     "icon": "ca.png",
@@ -1016,6 +1018,7 @@
     "slug": "debug",
     "editor": "Cozy Cloud",
     "vendorLink": "http://cozy.io",
+    "testing": true,
     "categories": ["other"],
     "fields": {
       "login": {
@@ -1121,6 +1124,7 @@
     "name": "Enedis",
     "editor": "Fing",
     "vendorLink": "https://www.enedis.fr/",
+    "testing": true,
     "categories": ["energy"],
     "frequency": "daily",
     "timeInterval": [4, 5],

--- a/src/ducks/registry/index.js
+++ b/src/ducks/registry/index.js
@@ -106,15 +106,7 @@ export const initializeRegistry = konnectors => {
         const filteredKonnectors =
           context.attributes && context.attributes.debug
             ? konnectors
-            : konnectors.filter(
-                k =>
-                  ![
-                    'barclays136',
-                    'creditagricole',
-                    'debug',
-                    'enedis'
-                  ].includes(k.slug)
-              )
+            : konnectors.filter(k => !k.testing)
 
         if (konnectorsToExclude && konnectorsToExclude.length) {
           return dispatch({


### PR DESCRIPTION
From a proposition from @ptbrowne, this PR allow to specify directly in `src/config/konnectors.json`  if a konnector is in "testing" mode and should appear only on instances having a context with `debug` to `true` (i.e. at least not in **production**)

See https://github.com/cozy/cozy-stack/blob/master/cozy.example.yaml#L223