### PR TITLE
Remove deprecated em()

### DIFF
--- a/src/ducks/connections/components/queue/styles.styl
+++ b/src/ducks/connections/components/queue/styles.styl
@@ -3,10 +3,10 @@
 .queue
     @extend $popover
     position: fixed
-    bottom: em(8px)
-    left: em(24px)
-    max-height: em(185px)
-    width: em(480px)
+    bottom: 0.5rem
+    left: 1.5rem
+    max-height: 11.5625rem
+    width: 30rem
     max-width: 90%
     border: 1px solid silver
     border-radius: 4px
@@ -28,7 +28,7 @@
     color: charcoal-grey
     font-weight: bold
     margin: 0
-    padding: em(8px) em(16px) em(8px)
+    padding: 0.5rem 1rem 0.5rem
 
     .queue-header-inner
         display: flex
@@ -49,8 +49,8 @@
     -moz-appearance: none
     border: none
     display: block
-    flex-grow: 0 0 em(2px)
-    max-height: em(2px)
+    flex-grow: 0 0 0.125rem
+    max-height: 0.125rem
     width: 100%
     margin: 0
 
@@ -69,7 +69,7 @@
     overflow: auto
 
 .queue--collapsed
-    height: em(40px)
+    height: 2.5rem
 
     .queue-content
         visibility: none
@@ -94,7 +94,7 @@
     align-items: center
     flex: 0 0 auto
     width: 100%
-    max-width: 'calc(100vw - %s)' % em(220px)
+    max-width: 'calc(100vw - %s)' % 13.75rem
     border-bottom: 1px solid silver
     position: relative
 
@@ -102,7 +102,7 @@
         position: absolute
         height: 48px
         background-color: #F5F6F7
-        border-top: #297EF1 solid em(2px)
+        border-top: #297EF1 solid 0.125rem
         z-index: -1
 
 
@@ -138,7 +138,7 @@
     .item-pending
         text-transform: uppercase
         color: dodger-blue
-        font-size: em(12px)
+        font-size: 0.75rem
         font-weight: bold
         line-height: 2em
 

--- a/src/ducks/connections/components/queue/styles.styl
+++ b/src/ducks/connections/components/queue/styles.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 .queue
     @extend $popover

--- a/src/styles/KonnectorSync.styl
+++ b/src/styles/KonnectorSync.styl
@@ -1,4 +1,5 @@
-@import cozy-ui
+@require 'settings/palette.styl'
+@require 'settings/icons.styl'
 
 text-button-color_bis = dodgerBlue
 
@@ -19,6 +20,6 @@ text-button-color_bis = dodgerBlue
         .submitting::after
             content ''
             margin  0 0 0 .5em
-            width   em(16px)
-            height  em(16px)
+            width   1rem
+            height  1rem
             @extend $icon-spinner-blue

--- a/src/styles/accountConnection.styl
+++ b/src/styles/accountConnection.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'tools/mixins.styl'
 
 :local // @stylint ignore
     h3

--- a/src/styles/accountConnection.styl
+++ b/src/styles/accountConnection.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     h3

--- a/src/styles/accountConnectionData.styl
+++ b/src/styles/accountConnectionData.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-account-connection-data

--- a/src/styles/accountConnectionData.styl
+++ b/src/styles/accountConnectionData.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'tools/mixins.styl'
 
 :local // @stylint ignore
     .col-account-connection-data
@@ -6,7 +6,7 @@
         min-width 25%
 
         h4
-            margin-bottom em(16px)
+            margin-bottom 1rem
 
     .col-account-connection-data-access
         margin-top 0

--- a/src/styles/accountLoginForm.styl
+++ b/src/styles/accountLoginForm.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'tools/mixins.styl'
+@require 'settings/palette.styl'
 
 :local // @stylint ignore
     .coz-form-controls
@@ -41,7 +42,7 @@
             background-color    white
             text-transform      uppercase
             font-weight         700
-            padding             em(2px) // Magic number to align button with form fields
+            padding             .125rem // Magic number to align button with form fields
 
     .account-form-fieldset
         padding   0

--- a/src/styles/accountLoginForm.styl
+++ b/src/styles/accountLoginForm.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .coz-form-controls

--- a/src/styles/accountLoginForm.styl
+++ b/src/styles/accountLoginForm.styl
@@ -35,7 +35,7 @@
         .col-account-form-advanced-button
             font-family         Lato, sans-serif
             cursor              pointer
-            margin              em(16px) 0 0
+            margin              1rem 0 0
             font-size           .8em
             border              0
             color               dodgerBlue

--- a/src/styles/accountLogout.styl
+++ b/src/styles/accountLogout.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-account-form-delete

--- a/src/styles/accountLogout.styl
+++ b/src/styles/accountLogout.styl
@@ -1,5 +1,3 @@
-@require 'cozy-ui'
-
 :local // @stylint ignore
     .col-account-form-delete
         .coz-btn

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -1,3 +1,8 @@
+@require 'objects/layouts.styl'
+@require 'tools/mixins.styl'
+@require 'components/button.styl'
+@require 'settings/palette.styl'
+
 .col-wrapper
     @extend $app-2panes-sticky
 

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -64,7 +64,7 @@
         max-width   400px
         width       100%
     h2
-        font-size   em(18px)
-        line-height em(24px)
+        font-size   1.125rem
+        line-height 1.5rem
     p
         color       coolGrey

--- a/src/styles/connectedTile.styl
+++ b/src/styles/connectedTile.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
 

--- a/src/styles/connectedTile.styl
+++ b/src/styles/connectedTile.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/icons.styl'
 
 :local // @stylint ignore
 

--- a/src/styles/connectionManagement.styl
+++ b/src/styles/connectionManagement.styl
@@ -1,4 +1,7 @@
-@require 'cozy-ui'
+@require 'settings/icons.styl'
+@require 'settings/palette.styl'
+@require 'tools/mixins.styl'
+
 
 // inside modal spinner
 .installing

--- a/src/styles/connectionManagement.styl
+++ b/src/styles/connectionManagement.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 // inside modal spinner
 .installing

--- a/src/styles/dataItem.styl
+++ b/src/styles/dataItem.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-data-item

--- a/src/styles/dataItem.styl
+++ b/src/styles/dataItem.styl
@@ -8,7 +8,7 @@
 
     .col-data-item-icon
         display    inline-block
-        max-width  em(32px)
-        max-height em(32px)
-        margin     em(8px)
-        margin-left em(4px)
+        max-width  2rem
+        max-height 2rem
+        margin     .5rem
+        margin-left .25rem

--- a/src/styles/dialog.styl
+++ b/src/styles/dialog.styl
@@ -1,3 +1,5 @@
+@require 'settings/palette.styl'
+
 // Global styles for forms
 .account-connection,
 .account-management

--- a/src/styles/field.styl
+++ b/src/styles/field.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
 
 text-button-color = dodgerBlue
 

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -8,15 +8,15 @@
         visibility hidden
 
 
-    @import './app.styl'
-    @import './sidebar.styl'
-    @import './lists.styl'
+    @require './app.styl'
+    @require './sidebar.styl'
+    @require './lists.styl'
 
-    @import './dialog.styl'
+    @require './dialog.styl'
 
-    @import './loading.styl'
-    @import './error.styl'
+    @require './loading.styl'
+    @require './error.styl'
 
-    @import './notifier.styl'
+    @require './notifier.styl'
 
-    @import './introjs-cozy.styl'
+    @require './introjs-cozy.styl'

--- a/src/styles/index.styl
+++ b/src/styles/index.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :global
     #svg-sprite-content

--- a/src/styles/konnectorEdit.styl
+++ b/src/styles/konnectorEdit.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-account-edit-content

--- a/src/styles/konnectorEdit.styl
+++ b/src/styles/konnectorEdit.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'tools/mixins.styl'
+@require 'settings/palette.styl'
 
 :local // @stylint ignore
     .col-account-edit-content

--- a/src/styles/konnectorFolder.styl
+++ b/src/styles/konnectorFolder.styl
@@ -1,4 +1,4 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
 
 :local // @stylint ignore
     .col-account-folder

--- a/src/styles/konnectorFolder.styl
+++ b/src/styles/konnectorFolder.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-account-folder

--- a/src/styles/konnectorFolder.styl
+++ b/src/styles/konnectorFolder.styl
@@ -2,7 +2,7 @@
 
 :local // @stylint ignore
     .col-account-folder
-        margin-top  em(32px)
+        margin-top  2rem
         position    relative
 
         &-highlighted-data
@@ -27,7 +27,7 @@
             background embedurl('../assets/icons/icon-openwith.svg') 0 no-repeat
             display block
             padding-left 1.3em
-            margin-top em(24px)
+            margin-top 1.5rem
 
         &-save-btn
             width 100%

--- a/src/styles/konnectorInstall.styl
+++ b/src/styles/konnectorInstall.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'tools/mixins.styl'
+@require 'settings/palette.styl'
 
 :local // @stylint ignore
     .col-account-connection-content

--- a/src/styles/konnectorInstall.styl
+++ b/src/styles/konnectorInstall.styl
@@ -16,8 +16,8 @@
     .col-account-connection-security
         display      flex
         align-items  center
-        margin-bottom em(8px)
-        margin-top    em(24px)
+        margin-bottom 0.5rem
+        margin-top    1.5rem
 
     .col-account-connection-security svg
         max-height   (48/basefont)em

--- a/src/styles/konnectorInstall.styl
+++ b/src/styles/konnectorInstall.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .col-account-connection-content

--- a/src/styles/konnectorMaintenance.styl
+++ b/src/styles/konnectorMaintenance.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :local // @stylint ignore
     .maintenance

--- a/src/styles/konnectorMaintenance.styl
+++ b/src/styles/konnectorMaintenance.styl
@@ -1,17 +1,15 @@
-@require 'cozy-ui'
-
 :local // @stylint ignore
-    .maintenance
-        &-intro
-            text-align center
-            color #f52d2d
-            margin: em(16px) auto
+    .maintenance-intro
+        text-align center
+        color #f52d2d
+        margin 1rem auto
 
-        &-icon
-            width em(100px)
-            height em(100px)
-            margin 0 auto
-            background embedurl('../assets/icons/icon-maintenance.svg') 0 no-repeat
+    .maintenance-service
+        font-size 1.125rem
 
-        &-service
-            font-size em(18px)
+    .maintenance-icon
+        width 6.25rem
+        height 6.25rem
+        margin 0 auto
+        background embedurl('../assets/icons/icon-maintenance.svg') 0 no-repeat
+

--- a/src/styles/konnectorSuccess.styl
+++ b/src/styles/konnectorSuccess.styl
@@ -1,3 +1,2 @@
-@require 'cozy-ui'
-@import './accountLoginForm'
-@import './konnectorFolder'
+@require './accountLoginForm'
+@require './konnectorFolder'

--- a/src/styles/konnectorSuccess.styl
+++ b/src/styles/konnectorSuccess.styl
@@ -1,3 +1,3 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 @import './accountLoginForm'
 @import './konnectorFolder'

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -1,3 +1,5 @@
+@require 'settings/palette.styl'
+
 .connector-list
     display          flex
     flex-wrap        wrap
@@ -49,7 +51,7 @@ $item-margin = .8em
         padding     0 .5em
         margin      .5em
         color       black
-        font-size   em(20px)
+        font-size   1.25rem
         font-weight 700
     .item-subtitle
         font-size       14px

--- a/src/styles/loading.styl
+++ b/src/styles/loading.styl
@@ -1,20 +1,24 @@
+@require 'settings/icons.styl'
+@require 'settings/palette.styl'
+@require 'tools/mixins.styl'
+
 .coz-loading, .coz-loading--no-margin
     text-align center
     &:before
         content     ''
-        margin      em(80px) auto 0
-        width       em(80px)
-        height      em(80px)
+        margin      5rem auto 0
+        width       5rem
+        height      5rem
         @extend $icon-spinner-blue
 
     h2
-        font-size(24px)
-        margin         em(33px) auto 0
+        font-size      1.5rem
+        margin         2.0625rem auto 0
         line-height    1.3
         color          charcoalGrey
         letter-spacing -.2px
     p
-        margin-top  em(15px)
+        margin-top  .9375rem
         color       coolGrey
         line-height 1.5
 
@@ -26,9 +30,11 @@
 @media (max-width: (1023/basefont)rem)
     .coz-empty
         &:before
-            width  em(55px)
-            height em(55px)
+            width  3.4375rem
+            height 3.4375rem
+
         h2
-            margin em(33px) 1.5em 0
+            margin 3.4375rem 1.5em 0
+
         p
-            margin em(5px) 1.5em 0
+            margin .3125rem 1.5em 0

--- a/src/styles/notifier.styl
+++ b/src/styles/notifier.styl
@@ -1,3 +1,6 @@
+@require 'tools/mixins.styl'
+@require 'settings/palette.styl'
+
 // Onboarding notification styles
 // TODO: use the one in cozy-ui ?
 notification-width = (546/basefont)em
@@ -29,12 +32,12 @@ notification-width = (546/basefont)em
     cursor                     pointer
 
     .coz-notification-title
-        font-size(18px)
+        font-size   1.125rem
         font-weight bold
 
     .coz-notification-details
-        margin-top em(5px)
-        font-size(15px)
+        margin-top .3125rem
+        font-size  .9375rem
 
 .coz-notification--error
     background-color pomegranate

--- a/src/styles/services.styl
+++ b/src/styles/services.styl
@@ -1,4 +1,4 @@
-@import 'cozy-ui'
+@require 'cozy-ui'
 
 :global // @stylint ignore
     #svg-sprite-content

--- a/src/styles/services.styl
+++ b/src/styles/services.styl
@@ -1,4 +1,6 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
+@require 'tools/mixins.styl'
+@require 'settings/icons.styl'
 
 :global // @stylint ignore
     #svg-sprite-content
@@ -7,9 +9,9 @@
         height 0
         visibility hidden
 
-    @import './lists.styl'
-    @import './loading.styl'
-    @import './dialog.styl'
+    @require './lists.styl'
+    @require './loading.styl'
+    @require './dialog.styl'
 
     .coz-service-loading
     .coz-service-error

--- a/src/styles/sidebar.styl
+++ b/src/styles/sidebar.styl
@@ -1,4 +1,5 @@
-@require 'cozy-ui'
+@require 'settings/palette.styl'
+
 
 // related to categories submenu
 .col-nav-submenu
@@ -12,7 +13,7 @@
         padding         .5em 1em
         margin          0
         border-radius   4px 0 0 4px
-        font-size       em(14px)
+        font-size       .875rem
         color           charcoalGrey
         text-decoration none
 


### PR DESCRIPTION
Remove deprecated em() and *only import what's needed*. This improve build time from 46s to 26s.