### PR TITLE
feat: add bank categorization konnector (testing)

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -636,6 +636,19 @@
     }
   },
   {
+    "name": "Bank Categorization",
+    "slug": "bankcategorization",
+    "editor": "Cozy Cloud",
+    "vendorLink": "http://cozy.io",
+    "testing": true,
+    "categories": ["other"],
+    "dataType": [
+      "bankTransactions"
+    ],
+    "fields": {},
+    "source": "git://github.com/konnectors/cozy-konnector-bank-categorization.git#build"
+  },
+  {
     "slug": "cdngroup109",
     "name": "Société Marseillaise de Crédit (Particuliers)",
     "editor": "Cozy Cloud",

--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -646,7 +646,7 @@
       "bankTransactions"
     ],
     "fields": {},
-    "source": "git://github.com/konnectors/cozy-konnector-bank-categorization.git#build"
+    "source": "git://github.com/konnectors/cozy-konnector-bank-categorization.git#latest"
   },
   {
     "slug": "cdngroup109",


### PR DESCRIPTION
Add bank categorization connector in testing mode. This connector's goal is to collect the user's bank operations to send it to @francoisWeber algorithm.