### PR TITLE
feat: add timeout field for Debug konnector ⏳

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1128,6 +1128,10 @@
       "password": {
         "type": "password"
       },
+      "timeout": {
+        "type": "text",
+        "default": "1000"
+      },
       "advancedFields": {
         "folderPath": {
           "advanced": true,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,7 @@
         "token": "Token",
         "agreement": "I agree",
         "refreshToken": "Refresh Token",
+        "timeout": "Delay (ms)",
         "branchName": "Branch",
         "code": "Confidential code"
       },


### PR DESCRIPTION
This allows users to set the field `timeout` which may be used by `cozy-konnector-debug`, [see here](https://github.com/cozy/cozy-konnector-debug/blob/master/index.js#L6).