### PR TITLE
Make enedis connector available. Update description message.

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1229,7 +1229,6 @@
     "name": "Enedis",
     "editor": "Fing",
     "vendorLink": "https://www.enedis.fr/",
-    "testing": true,
     "categories": ["energy"],
     "frequency": "daily",
     "timeInterval": [4, 5],

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -344,8 +344,7 @@
     },
     "enedis": {
       "description": {
-        "service": "This connector is provided by the Fing. With this tools, you can get your personnal data from Enedis and store them in your Cozy. It will bring back daily the data about your electric consumption measured by your Linky counter (energy, maxpower and load curve by day), and a few data about your account (contact information, postal address, counter informations). This tool is run by your Cozy and the Fing will not have any access or view of the data."
-      }
+        "service": "Recover your Linky data by connecting your Enedis account. You must have a Linky meter and have first created your Enedis account (on the [Enedis website](https://espace-client-connexion.enedis.fr/auth/UI/Login?realm=particuliers). This connector is provided by Fing for the MesInfos project. It retrieves the data from your electricity contract and downloads your electricity consumption the day before. This connector is running on your Cozy and the Fing will have no access to this data."      }
     },
     "orange": {
       "message": {


### PR DESCRIPTION
Make Enedis konnector viewable (but it should be only usable by MesInfos users for now !)

Update description. The french translation would be :

Récupérez vos données Linky en connectant votre compte Enedis. Vous devez être équipé d’un compteur Linky et avoir au préalable créé votre espace client Enedis (sur le [site Enedis](https://espace-client-connexion.enedis.fr/auth/UI/Login?realm=particuliers)). Ce connecteur est fourni par la Fing pour le projet MesInfos. Il récupère les données de votre contrat d’électricité et télécharge tous les matins votre consommation d’électricité de la veille. Ce connecteur est exécuté sur votre Cozy et  la Fing n'aura aucun accès à ces données.

ping @poupotte  : )

#### Checklist

Before merging this PR, the following things must have been done:

- [ ] Faithful integration of the mockups at all screen sizes
- [ ] Tested on supported browsers, including responsive mode (IE11 and Edge, Chrome >= 42, 2 latest versions of Firefox and Safari)
- [ ] Localized in english and french
- [ ] All changes have test coverage
- [ ] Updated README, if necessary

If this PR relies on changes in one of our internal libraries (cozy-client-js or cozy-ui, for example), please also do the following things:

- [ ] The package.json and yarn.lock files include the correct dependency version, in those versions have been released
- [ ] [cozy-client-js](https://github.com/cozy/cozy-client-js) documentation and tests are up to date
- [ ] [cozy-ui](https://github.com/cozy/cozy-ui) documentation and style guides are up to date

*(If not, please remove this last section.)*
