### PR TITLE
fix: cozy-ui regressions 💄

### DIFF
--- a/src/components/ConnectedList.jsx
+++ b/src/components/ConnectedList.jsx
@@ -41,8 +41,10 @@ class ConnectedList extends Component {
           <h1 className="col-top-bar-title">{t('nav.connected')}</h1>
           {connections.length > 0 && (
             <NavLink to="/providers/all" className="col-button">
-              <Icon icon={addAccountIcon} className="col-icon--add" />&nbsp;
-              {t('add_account')}
+              <span>
+                <Icon icon={addAccountIcon} className="col-icon--add" />&nbsp;
+                {t('add_account')}
+              </span>
             </NavLink>
           )}
         </div>
@@ -69,7 +71,7 @@ class ConnectedList extends Component {
               <h2>{t('connector.no-connectors-connected')}</h2>
               <p>{t('connector.get-info')}</p>
               <NavLink to="/providers/all" className="col-button">
-                {t('connector.connect-account')}
+                <span>{t('connector.connect-account')}</span>
               </NavLink>
             </div>
           </div>

--- a/src/components/KonnectorHeaderIcon.jsx
+++ b/src/components/KonnectorHeaderIcon.jsx
@@ -1,0 +1,15 @@
+import styles from '../styles/konnectorHeaderIcon'
+import React from 'react'
+
+import { getKonnectorIcon } from '../lib/icons'
+
+export const KonnectorHeaderIcon = ({ konnector }) => (
+  <div className={styles['col-konnector-header-icon-wrapper']}>
+    <img
+      className={styles['col-konnector-header-icon']}
+      src={getKonnectorIcon(konnector)}
+    />
+  </div>
+)
+
+export default KonnectorHeaderIcon

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -68,7 +68,9 @@ export const KonnectorSuccess = ({
                 to={`/connected/${connector.slug}/${account._id}`}
                 className={classNames(styles['coz-btn'], 'col-button')}
               >
-                {successButtonLabel || t('account.success.button.config')}
+                <span>
+                  {successButtonLabel || t('account.success.button.config')}
+                </span>
               </NavLink>
             </p>
           </div>

--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 
 import AccountConnection from '../../containers/AccountConnection'
+import KonnectorHeaderIcon from '../../components/KonnectorHeaderIcon'
 
 import { connect } from 'react-redux'
 
@@ -49,6 +50,9 @@ class CreateAccountService extends React.Component {
     const { values } = this.state
     return (
       <div className="coz-service-content">
+        <header className="coz-service-content-header">
+          <KonnectorHeaderIcon konnector={konnector} />
+        </header>
         <AccountConnection
           connector={konnector}
           onNext={account => this.onSuccess(account)}

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -13,13 +13,11 @@ import {
 } from '../ducks/connections'
 import { getKonnectorTriggersCount } from '../reducers'
 import { fetchAccount } from '../ducks/accounts'
-import classNames from 'classnames'
 
 import { translate } from 'cozy-ui/react/I18n'
 
 import KonnectorInstall from '../components/KonnectorInstall'
 import KonnectorEdit from '../components/KonnectorEdit'
-import { getKonnectorIcon } from '../lib/icons'
 import { popupCenter, waitForClosedPopup } from '../lib/popup'
 import statefulForm from '../lib/statefulForm'
 
@@ -351,16 +349,6 @@ class AccountConnection extends Component {
       success || queued ? this.buildSuccessMessages(konnector) : []
     return (
       <div className={styles['col-account-connection']}>
-        <div className={styles['col-account-connection-header']}>
-          <img
-            className={classNames(
-              styles['col-account-connection-icon'],
-              'col-account-connection-icon'
-            )}
-            src={getKonnectorIcon(konnector)}
-          />
-        </div>
-
         {editing ? ( // Properly load the edit view or the initial config view
           <KonnectorEdit
             isFetching={isFetching}

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -23,8 +23,9 @@ import {
   getKonnectorsInMaintenance
 } from '../reducers'
 
-import Modal, { ModalContent } from 'cozy-ui/react/Modal'
+import Modal, { ModalContent, ModalHeader } from 'cozy-ui/react/Modal'
 import AccountConnection from './AccountConnection'
+import KonnectorHeaderIcon from '../components/KonnectorHeaderIcon'
 import Notifier from '../components/Notifier'
 
 class ConnectionManagement extends Component {
@@ -113,6 +114,11 @@ class ConnectionManagement extends Component {
         dismissAction={() => this.gotoParent()}
         className={styles['col-account-modal']}
       >
+        <ModalHeader>
+          <div className={styles['col-account-connection-header']}>
+            <KonnectorHeaderIcon konnector={konnector} />
+          </div>
+        </ModalHeader>
         <ModalContent>
           {isWorking ? (
             <div className={styles['installing']}>

--- a/src/styles/accountConnection.styl
+++ b/src/styles/accountConnection.styl
@@ -24,9 +24,6 @@
         svg
             max-height (48/basefont)em
 
-    .col-account-connection-icon
-        height 3em
-
     @media (max-width: (400/basefont)rem)
         h4
             font-size   (18/basefont)em

--- a/src/styles/accountConnectionData.styl
+++ b/src/styles/accountConnectionData.styl
@@ -2,7 +2,7 @@
 
 :local // @stylint ignore
     .col-account-connection-data
-        margin 0 (16/basefont)em
+        margin 0 0 0 (16/basefont)em
         min-width 25%
 
         h4

--- a/src/styles/konnectorHeaderIcon.styl
+++ b/src/styles/konnectorHeaderIcon.styl
@@ -1,0 +1,3 @@
+:local
+  .col-konnector-header-icon
+    height 3em

--- a/src/styles/konnectorInstall.styl
+++ b/src/styles/konnectorInstall.styl
@@ -26,7 +26,7 @@
         margin-right (16/basefont)em
 
     .col-account-connection-form
-        margin 0 (16/basefont)em
+        margin 0 (16/basefont)em 0 0
         min-width 60%
 
     @media (max-width: (768/basefont)rem)

--- a/src/styles/lists.styl
+++ b/src/styles/lists.styl
@@ -80,6 +80,7 @@ $item-margin = .8em
 
 .col-voting-item
     border      2px dashed alpha(black, .15)
+    padding-bottom: .5em
     &:hover
         box-shadow  none
     .item-title

--- a/src/styles/services.styl
+++ b/src/styles/services.styl
@@ -83,16 +83,23 @@
             // overide default bg position
             background-position  center right
 
+    .coz-service-content-header
+        width: 100%
 
     .coz-service-content
         flex    1
         display flex
         max-height      calc(100vh - (32/basefont)em)
-        justify-content center
+        justify-content: start
         padding         (16/basefont)em
+        flex-direction: column
+        width: 70%
+        // width at wich the header "separates" from content to continue its way
+        // to the left.
+        max-width: 68rem
+        align-items: center
+        margin: (48/basefont)em auto
 
-        .col-account-connection-icon
-            margin-top 3em
 
     .coz-service-return + .coz-service-content
         .col-account-connection-icon


### PR DESCRIPTION
This PR :

## Fix the buttons after cozy-ui breaking changes

![capture d ecran 2018-03-26 a 22 26 52](https://user-images.githubusercontent.com/776764/37931071-cd63af92-3144-11e8-9588-cb28b5f3fc10.png)
----
## Fix tile height in the voting tile row when viewport is too thin.

![capture d ecran 2018-03-26 a 16 35 42](https://user-images.githubusercontent.com/776764/37931111-e4cd4a08-3144-11e8-9da4-89e88346f528.png)
----
## Move the konnector icon into the modal header.

![capture d ecran 2018-03-26 a 22 28 15](https://user-images.githubusercontent.com/776764/37931142-ffaf3818-3144-11e8-8d7e-29c305be71f6.png)


