### PR TITLE
fix: do not use bulk for deletion as delete events are not sent by the stack

### DIFF
--- a/src/targets/services/cleanOrphanAccounts.js
+++ b/src/targets/services/cleanOrphanAccounts.js
@@ -70,12 +70,14 @@ const indexTriggersByAccounts = triggers =>
 
 const deleteAccounts = async accounts => {
   log.info(`Deleting accounts ${accounts.map(doc => doc._id).join(', ')}`)
-  await cozyFetch(
-    'POST',
-    `data/io.cozy.accounts/_bulk_docs`,
-    { docs: accounts.map(doc => ({ ...doc, _deleted: true })) },
-    true
-  )
+  for (let acc of accounts) {
+    await cozyFetch(
+      'DELETE',
+      `data/io.cozy.accounts/${acc._id}?rev=${acc._rev}`,
+      null,
+      true
+    )
+  }
 }
 
 const cleanOrphanAccounts = async () => {


### PR DESCRIPTION
We rely on internal stack events to trigger post deletion jobs. The deletion
event does not seem to be correclty sent when using the
bulk route. This is surprising as some work had been done to ensure the right
event was sent (https://github.com/cozy/cozy-stack/pull/1272).

Here I go back to the previous method of deleting one by one each document to
ensure we have something working.