### PR TITLE
feat: update google konnector's scope

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1399,7 +1399,8 @@
     },
     "dataType": ["contact"],
     "source": "git://github.com/konnectors/cozy-konnector-google.git#latest",
-    "oauth_scope": "https://www.googleapis.com/auth/contacts.readonly"
+    "oauth_scope":
+      "https://www.googleapis.com/auth/contacts.readonly+https://www.googleapis.com/auth/userinfo.email"
   },
   {
     "slug": "harmonie",


### PR DESCRIPTION
We updated the connector which now needs a wider scope, notably to retrieve the email address of the user's google account in order to be able to do the binding between cozy contacts and google contacts.

See https://github.com/konnectors/cozy-konnector-google/pull/22 for more details about the needs.