### PR TITLE
feat: link directly to the store ✨

### DIFF
--- a/src/components/ConnectedList.jsx
+++ b/src/components/ConnectedList.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 
+import { ButtonLink } from 'cozy-ui/react/Button'
 import Icon from 'cozy-ui/react/Icon'
 import { connect } from 'react-redux'
 import { Route, NavLink } from 'react-router-dom'
 import { getConnectedKonnectors } from '../reducers'
+import { getAppUrl } from '../ducks/apps'
 import { translate } from 'cozy-ui/react/I18n'
 import { isTutorial, display as displayTutorial } from '../lib/tutorial'
 
@@ -33,7 +35,7 @@ class ConnectedList extends Component {
   }
 
   render() {
-    const { t, connectedKonnectors, wrapper } = this.props
+    const { t, connectedKonnectors, cozyStoreURL, wrapper } = this.props
     const hasConnections = !!connectedKonnectors.length
     return (
       <div className="content">
@@ -68,9 +70,11 @@ class ConnectedList extends Component {
             <div>
               <h2>{t('connector.no-connectors-connected')}</h2>
               <p>{t('connector.get-info')}</p>
-              <NavLink to="/providers/all" className="col-button">
-                {t('connector.connect-account')}
-              </NavLink>
+              <ButtonLink
+                disabled={!cozyStoreURL}
+                href={cozyStoreURL}
+                label={t('connector.connect-account')}
+              />
             </div>
           </div>
         )}
@@ -85,7 +89,8 @@ class ConnectedList extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-    connectedKonnectors: getConnectedKonnectors(state)
+    connectedKonnectors: getConnectedKonnectors(state),
+    cozyStoreURL: getAppUrl(state.cozy, 'store')
   }
 }
 

--- a/src/components/appEntryPoint.jsx
+++ b/src/components/appEntryPoint.jsx
@@ -2,6 +2,7 @@ import { cozyConnect } from 'redux-cozy-client'
 
 import { initializeRegistry } from '../ducks/registry'
 import { fetchAccounts } from '../ducks/accounts'
+import { fetchApps } from '../ducks/apps'
 import { fetchKonnectorJobs } from '../ducks/jobs'
 import { fetchKonnectors } from '../ducks/konnectors'
 import { fetchTriggers } from '../ducks/triggers'
@@ -12,6 +13,7 @@ const mapActionsToProps = dispatch => ({
 
 const mapDocumentsToProps = (state, ownProps) => ({
   accounts: fetchAccounts(),
+  apps: fetchApps(),
   jobs: fetchKonnectorJobs(),
   konnectors: fetchKonnectors(),
   triggers: fetchTriggers()

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -1,5 +1,18 @@
 import * as fromCozyClient from 'redux-cozy-client'
 
+const APPS_DOCTYPE = 'io.cozy.apps'
 const APPS_KEY = 'apps'
 
 export const fetchApps = () => fromCozyClient.fetchApps(APPS_KEY)
+
+// selectors
+const getApp = (state, slug) =>
+  state &&
+  state.documents &&
+  state.documents[APPS_DOCTYPE] &&
+  state.documents[APPS_DOCTYPE][`${APPS_DOCTYPE}/${slug}`]
+
+export const getAppUrl = (state, slug) => {
+  const app = getApp(state, slug)
+  return app && app.links && app.links.related
+}

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -1,0 +1,5 @@
+import * as fromCozyClient from 'redux-cozy-client'
+
+const APPS_KEY = 'apps'
+
+export const fetchApps = () => fromCozyClient.fetchApps(APPS_KEY)

--- a/src/lib/redux-cozy-client/CozyClient.js
+++ b/src/lib/redux-cozy-client/CozyClient.js
@@ -2,6 +2,7 @@
 import DataAccessFacade from './DataAccessFacade'
 import { authenticateWithCordova } from './authentication/mobile'
 
+const APPS_DOCTYPE = 'io.cozy.apps'
 const FILES_DOCTYPE = 'io.cozy.files'
 const TRIGGERS_DOCTYPE = 'io.cozy.triggers'
 const SHARINGS_DOCTYPE = 'io.cozy.sharings'
@@ -59,6 +60,10 @@ export default class CozyClient {
 
   getAdapter(doctype) {
     return this.facade.getAdapter(doctype)
+  }
+
+  async fetchApps(name, options = {}, skip = 0) {
+    return this.getAdapter(APPS_DOCTYPE).fetchApps()
   }
 
   async fetchCollection(name, doctype, options = {}, skip = 0) {

--- a/src/lib/redux-cozy-client/adapters/CozyStackAdapter.js
+++ b/src/lib/redux-cozy-client/adapters/CozyStackAdapter.js
@@ -7,6 +7,19 @@ export const SHARED_WITH_ME = 'sharedWithMe'
 export const SHARED_WITH_OTHERS = 'sharedWithOthers'
 
 export default class CozyStackAdapter {
+  async fetchApps(skip = 0) {
+    const { data, meta } = await cozy.client.fetchJSON('GET', '/apps/', null, {
+      processJSONAPI: false
+    })
+
+    return {
+      data: data || [],
+      meta: meta,
+      skip,
+      next: !!meta && meta.count > skip + FETCH_LIMIT
+    }
+  }
+
   async fetchDocuments(doctype) {
     // WARN: cozy-client-js lacks a cozy.data.findAll method that uses this route
     try {

--- a/src/lib/redux-cozy-client/index.js
+++ b/src/lib/redux-cozy-client/index.js
@@ -5,6 +5,7 @@ export { default as cozyMiddleware } from './middleware'
 export {
   default as reducer,
   makeActionCreator,
+  fetchApps,
   fetchCollection,
   fetchDocument,
   fetchReferencedFiles,

--- a/src/lib/redux-cozy-client/reducer.js
+++ b/src/lib/redux-cozy-client/reducer.js
@@ -7,6 +7,7 @@ import sharings, {
 } from './slices/sharings'
 import synchronization from './slices/synchronization'
 
+const APPS_DOCTYPE = 'io.cozy.apps'
 const FETCH_DOCUMENT = 'FETCH_DOCUMENT'
 const FETCH_COLLECTION = 'FETCH_COLLECTION'
 const LAUNCH_TRIGGER = 'LAUNCH_TRIGGER'
@@ -15,6 +16,7 @@ const RECEIVE_ERROR = 'RECEIVE_ERROR'
 export const CREATE_DOCUMENT = 'CREATE_DOCUMENT'
 const UPDATE_DOCUMENT = 'UPDATE_DOCUMENT'
 const DELETE_DOCUMENT = 'DELETE_DOCUMENT'
+const RECEIVE_APP = 'RECEIVE_APP'
 const RECEIVE_NEW_DOCUMENT = 'RECEIVE_NEW_DOCUMENT'
 const RECEIVE_UPDATED_DOCUMENT = 'RECEIVE_UPDATED_DOCUMENT'
 const RECEIVE_DELETED_DOCUMENT = 'RECEIVE_DELETED_DOCUMENT'
@@ -24,6 +26,16 @@ const REMOVE_REFERENCED_FILES = 'REMOVE_REFERENCED_FILES'
 
 const documents = (state = {}, action) => {
   switch (action.type) {
+    case RECEIVE_APP:
+      const apps = action.response && action.response.data
+      if (apps.length === 0) return state
+      return {
+        ...state,
+        [APPS_DOCTYPE]: {
+          ...state[APPS_DOCTYPE],
+          ...objectifyDocumentsArray(apps)
+        }
+      }
     case RECEIVE_DATA:
       const { data } = action.response
       if (data.length === 0) return state
@@ -159,6 +171,7 @@ const collection = (state = collectionInitialState, action) => {
         options: action.options,
         fetchStatus: action.skip > 0 ? 'loadingMore' : 'loading'
       }
+    case RECEIVE_APP:
     case RECEIVE_DATA:
       const response = action.response
       return {
@@ -222,6 +235,7 @@ const collections = (state = {}, action) => {
     case FETCH_REFERENCED_FILES:
     case ADD_REFERENCED_FILES:
     case REMOVE_REFERENCED_FILES:
+    case RECEIVE_APP:
     case RECEIVE_DATA:
     case RECEIVE_ERROR:
       if (!action.collection) {
@@ -250,6 +264,15 @@ export default combineReducers({
   documents,
   sharings,
   synchronization
+})
+
+export const fetchApps = (name, options = {}, skip = 0) => ({
+  types: [FETCH_COLLECTION, RECEIVE_APP, RECEIVE_ERROR],
+  collection: name,
+  doctype: 'io.cozy.apps',
+  options,
+  skip,
+  promise: client => client.fetchApps(name, options, skip)
 })
 
 export const fetchCollection = (name, doctype, options = {}, skip = 0) => ({


### PR DESCRIPTION
This PR links the button _Connect my accounts_ directly to the Cozy-Store app.

To do this, we :
* Load the apps list in cozy redux state, so the version of `redux-cozy-client` needs a little update. @goldoraf showed me how special collections are handled in the next version of `redux-cozy-client` but it needs more work and we are a little bit short for this card. I hope to get he next version of `redux-cozy-client` later.
* Select the store app and get its url.

![capture d ecran 2018-03-30 a 16 41 18](https://user-images.githubusercontent.com/776764/38141656-767dea4c-3439-11e8-9b15-9babf9972c8e.png)

