### PR TITLE
Fix intent termination

### DIFF
--- a/src/components/intents/CreateAccountIntent.jsx
+++ b/src/components/intents/CreateAccountIntent.jsx
@@ -14,7 +14,7 @@ const CreateAccountIntent = ({ konnector, onCancel, onTerminate }) => (
       <CreateAccountService
         konnector={konnector}
         onCancel={() => onCancel()}
-        onSuccess={account => onTerminate(account)}
+        onSuccess={onTerminate}
         closeModal={() => onCancel()}
       />
     )}

--- a/src/containers/IntentService.jsx
+++ b/src/containers/IntentService.jsx
@@ -35,7 +35,7 @@ class IntentService extends Component {
   }
 
   render() {
-    const { appData, konnector, onCancel } = this.props
+    const { appData, konnector, onCancel, service } = this.props
     const { error } = this.state
     const { t } = this.context
 
@@ -55,7 +55,7 @@ class IntentService extends Component {
               appData={appData}
               konnector={konnector}
               onCancel={onCancel}
-              onSuccess={account => this.onTerminate(account)}
+              onTerminate={service.terminate}
             />
           )}
       </div>


### PR DESCRIPTION
There a side effect at the end of an intent, which is automatically terminated. To fix this behavior, we need to dive deep into Modal's logic and it will need a little time. Waiting for this, we just close the intent when the account creation is done.