### PR TITLE
Use registry for published connectors

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -294,7 +294,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/blablacar.git#latest"
+    "source": "registry://blablacar/stable"
   },
   {
     "slug": "bnpparibas82",
@@ -351,7 +351,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/booking.com.git#latest"
+    "source": "registry://bookingdotcom/stable"
   },
   {
     "slug": "boulanger",
@@ -377,7 +377,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/boulanger.git#latest"
+    "source": "registry://boulanger/stable"
   },
   {
     "slug": "boursorama83",
@@ -432,7 +432,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-bouyguesbox.git#latest"
+    "source": "registry://bouyguesbox/stable"
   },
   {
     "slug": "bouyguestelecom",
@@ -457,7 +457,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-bouyguestelecom.git#latest"
+    "source": "registry://bouyguestelecom/stable"
   },
   {
     "slug": "bred",
@@ -867,7 +867,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-cesu.git#latest"
+    "source": "registry://cesu/stable"
   },
   {
     "slug": "cic45",
@@ -1292,7 +1292,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/darty.git#latest"
+    "source": "registry://darty/stable"
   },
   {
     "name": "Debug",
@@ -1347,7 +1347,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-digiposte.git#latest"
+    "source": "registry://digiposte/stable"
   },
   {
     "slug": "directenergie",
@@ -1553,7 +1553,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-free.git#latest"
+    "source": "registry://free/stable"
   },
   {
     "slug": "freemobile",
@@ -1578,7 +1578,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-free-mobile.git#latest"
+    "source": "registry://freemobile/stable"
   },
   {
     "slug": "generali",
@@ -1650,7 +1650,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-harmonie.git#latest"
+    "source": "registry://harmonie/stable"
   },
   {
     "slug": "hellobank145",
@@ -1743,7 +1743,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/impots.git#latest"
+    "source": "registry://impots/stable"
   },
   {
     "slug": "ingdirect95",
@@ -2030,7 +2030,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-malakoffmederic.git#latest"
+    "source": "registry://malakoffmederic/stable"
   },
   {
     "slug": "materielnet",
@@ -2081,7 +2081,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-mgen.git#latest"
+    "source": "registry://mgen/stable"
   },
   {
     "slug": "monabanq96",
@@ -2219,7 +2219,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-numericable.git#latest"
+    "source": "registry://numericable/stable"
   },
   {
     "slug": "orange",
@@ -2327,7 +2327,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-pajemploi.git#latest"
+    "source": "registry://pajemploi/stable"
   },
   {
     "slug": "payfit",
@@ -2477,7 +2477,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-sncf.git#latest"
+    "source": "registry://sncf/stable"
   },
   {
     "slug": "societegenerale",
@@ -2556,7 +2556,7 @@
         }
       }
     },
-    "source": "git://github.com/konnectors/cozy-konnector-sosh.git#latest"
+    "source": "registry://sosh/stable"
   },
   {
     "slug": "theoldreader",
@@ -2607,7 +2607,7 @@
     "dataType": [
       "bill"
     ],
-    "source": "git://github.com/konnectors/cozy-konnector-trainline.git#latest"
+    "source": "registry://trainline/stable"
   },
   {
     "slug": "vinciautoroute",
@@ -2634,6 +2634,6 @@
       "bill",
       "consumption"
     ],
-    "source": "git://github.com/konnectors/vinciautoroute.git#latest"
+    "source": "registry://vinciautoroute/stable"
   }
 ]


### PR DESCRIPTION
Use registry source for connectors with stable versions published