### PR TITLE
Remove testing flag from ldlc connector

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1926,7 +1926,6 @@
     "dataType": [
       "bill"
     ],
-    "testing": true,
     "source": "git://github.com/konnectors/ldlc.git#latest"
   },
   {


### PR DESCRIPTION
This connector is ready to go to prod.
Branch latest tested on integration.