### PR TITLE
Add actionable error message for outdated oauth

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -179,6 +179,10 @@
         "title": "Action needed on the provider",
         "description": "It seems that the [%{name}](%{link}) website requires you to log in and to do a specific action. Please rerun the connector once you have settled the issue on the website."
       },
+      "USER_ACTION_NEEDED.OAUTH_OUTDATED": {
+        "title": "Access refresh required",
+        "description": "It seems that the [%{name}](%{link}) website requires you to refresh the access you gave to the connector. Please disconnect and reconnect this connector. No data will be lost."
+      },
       "USER_ACTION_NEEDED.ACCOUNT_REMOVED": {
         "title": "Unavailable account",
         "description": "It seems that your account is no longer active. Please check your account on [%{name}](%{link}) before retry."


### PR DESCRIPTION
Some konnectors use Oauth and lose their refresh token.
This let the user knows she needs to disconnect / reconnect.
