### PR TITLE
Better 'onDone' management in KonnectorSuccess and AccountConnection

### DIFF
--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -13,42 +13,38 @@ import ErrorDescription from './ErrorDescriptions'
 
 import securityIcon from '../assets/icons/color/icon-cloud-lock.svg'
 
-export const KonnectorInstall = ({
-  t,
-  account,
-  connector,
-  deleting,
-  disableSuccessTimeout,
-  driveUrl,
-  error,
-  fields,
-  onBack,
-  queued,
-  isUnloading,
-  oAuthTerminated,
-  onCancel,
-  editing,
-  onDelete,
-  onNext,
-  onSubmit,
-  submit,
-  submitting,
-  success,
-  successMessage,
-  successMessages,
-  trigger,
-  allRequiredFieldsAreFilled,
-  displayAdvanced,
-  toggleAdvanced,
-  isFetching,
-  isValid,
-  isSuccess,
-  dirty,
-  successButtonLabel,
-  accountsCount,
-  maintenance,
-  lang
-}) => {
+export const KonnectorInstall = props => {
+  const {
+    t,
+    account,
+    connector,
+    disableSuccessTimeout,
+    driveUrl,
+    error,
+    fields,
+    onBack,
+    queued,
+    isUnloading,
+    oAuthTerminated,
+    onCancel,
+    editing,
+    onSubmit,
+    submitting,
+    success,
+    successMessage,
+    successMessages,
+    trigger,
+    allRequiredFieldsAreFilled,
+    displayAdvanced,
+    toggleAdvanced,
+    isFetching,
+    isValid,
+    isSuccess,
+    dirty,
+    successButtonLabel,
+    maintenance,
+    lang
+  } = props
   const { hasDescriptions, editor } = connector
   const hasLoginError = isKonnectorLoginError(error)
   const hasErrorExceptLogin = !!error && !hasLoginError
@@ -117,7 +113,6 @@ export const KonnectorInstall = ({
             folderId={trigger && trigger.message.folder_to_save}
             isRunningInQueue={isRunningInQueue}
             isUnloading={isUnloading}
-            onNext={onNext}
             onCancel={onCancel}
             success={success}
             title={successMessage}

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -28,6 +28,7 @@ export const KonnectorInstall = props => {
     oAuthTerminated,
     onCancel,
     editing,
+    onDone,
     onSubmit,
     submitting,
     success,
@@ -113,6 +114,7 @@ export const KonnectorInstall = props => {
             folderId={trigger && trigger.message.folder_to_save}
             isRunningInQueue={isRunningInQueue}
             isUnloading={isUnloading}
+            onDone={onDone}
             onCancel={onCancel}
             success={success}
             title={successMessage}

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -1,28 +1,26 @@
 import styles from '../styles/konnectorSuccess'
 
 import React from 'react'
-
-import Button from 'cozy-ui/react/Button'
 import { translate } from 'cozy-ui/react/I18n'
 import { NavLink } from 'react-router-dom'
+import classNames from 'classnames'
 
 import DescriptionContent from './DescriptionContent'
 
-export const KonnectorSuccess = ({
-  t,
-  connector,
-  isRunningInQueue,
-  onBack,
-  account,
-  error,
-  folderId,
-  onCancel,
-  onNext,
-  driveUrl,
-  title,
-  messages,
-  successButtonLabel
-}) => {
+export const KonnectorSuccess = props => {
+  const {
+    t,
+    connector,
+    isRunningInQueue,
+    onBack,
+    account,
+    error,
+    folderId,
+    driveUrl,
+    title,
+    messages,
+    successButtonLabel
+  } = props
   return (
     account && (
       <div>
@@ -30,8 +28,8 @@ export const KonnectorSuccess = ({
           title={!error && title}
           messages={!error && messages}
         >
-          {Array.isArray(connector.data_types) &&
-            connector.data_types.includes('bill') && (
+          {Array.isArray(connector.data_type) &&
+            connector.data_type.includes('bill') && (
               <p>
                 {!error &&
                   t(
@@ -66,13 +64,15 @@ export const KonnectorSuccess = ({
         <div className={styles['coz-form-controls']}>
           <div className={styles['col-account-form-success-buttons']}>
             <p>
-              <Button
-                label={successButtonLabel || t('account.success.button.config')}
-                onClick={onBack}
-                size="full"
-                tag={NavLink}
+              <NavLink
                 to={`/connected/${connector.slug}/accounts/${account._id}`}
-              />
+                onClick={onBack}
+                className={classNames(styles['coz-btn'], 'col-button')}
+              >
+                <span>
+                  {successButtonLabel || t('account.success.button.config')}
+                </span>
+              </NavLink>
             </p>
           </div>
         </div>

--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -1,9 +1,8 @@
 import styles from '../styles/konnectorSuccess'
 
 import React from 'react'
+import Button from 'cozy-ui/react/Button'
 import { translate } from 'cozy-ui/react/I18n'
-import { NavLink } from 'react-router-dom'
-import classNames from 'classnames'
 
 import DescriptionContent from './DescriptionContent'
 
@@ -12,13 +11,13 @@ export const KonnectorSuccess = props => {
     t,
     connector,
     isRunningInQueue,
-    onBack,
     account,
     error,
     folderId,
     driveUrl,
     title,
     messages,
+    onDone,
     successButtonLabel
   } = props
   return (
@@ -64,15 +63,12 @@ export const KonnectorSuccess = props => {
         <div className={styles['coz-form-controls']}>
           <div className={styles['col-account-form-success-buttons']}>
             <p>
-              <NavLink
-                to={`/connected/${connector.slug}/accounts/${account._id}`}
-                onClick={onBack}
-                className={classNames(styles['coz-btn'], 'col-button')}
-              >
-                <span>
-                  {successButtonLabel || t('account.success.button.config')}
-                </span>
-              </NavLink>
+              <Button
+                label={successButtonLabel || t('account.success.button.config')}
+                onClick={() => {
+                  onDone(account)
+                }}
+              />
             </p>
           </div>
         </div>

--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -50,7 +50,6 @@ class CreateAccountService extends React.Component {
       <div className="coz-service-content">
         <AccountConnection
           connector={konnector}
-          onNext={account => this.onSuccess(account)}
           successButtonLabel={t('intent.service.success.button.label')}
           values={values}
           {...this.props}

--- a/src/components/services/CreateAccountService.jsx
+++ b/src/components/services/CreateAccountService.jsx
@@ -38,7 +38,7 @@ class CreateAccountService extends React.Component {
     this.props.startCreation(this.props.konnector)
   }
 
-  onSuccess(account) {
+  onSuccess = account => {
     this.props.endCreation()
     this.props.onSuccess(account)
   }
@@ -50,6 +50,7 @@ class CreateAccountService extends React.Component {
       <div className="coz-service-content">
         <AccountConnection
           connector={konnector}
+          onDone={this.onSuccess}
           successButtonLabel={t('intent.service.success.button.label')}
           values={values}
           {...this.props}

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -44,15 +44,10 @@ class AccountConnection extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { existingAccount, success } = nextProps
+    const { existingAccount } = nextProps
 
-    const hasJustSucceed = !this.props.success && success
     const accountHasJustBeenCreated =
       !this.props.existingAccount && !!existingAccount
-
-    if (hasJustSucceed && this.props.onSuccess) {
-      this.props.onSuccess(this.state.account)
-    }
 
     if (accountHasJustBeenCreated) {
       this.setState({
@@ -310,7 +305,6 @@ class AccountConnection extends Component {
       disableSuccessTimeout,
       displayAccountsCount,
       isUnloading,
-      onBack,
       allRequiredFieldsAreFilled,
       allRequiredFilledButPasswords,
       displayAdvanced,
@@ -326,6 +320,7 @@ class AccountConnection extends Component {
       error,
       forceConnection,
       isRunning,
+      onDone,
       queued,
       t,
       trigger,
@@ -385,7 +380,6 @@ class AccountConnection extends Component {
           <KonnectorInstall
             displayAccountsCount={displayAccountsCount}
             isFetching={isFetching}
-            onBack={onBack}
             account={createdAccount}
             connector={konnector}
             isValid={isValid}
@@ -398,6 +392,7 @@ class AccountConnection extends Component {
             queued={queued}
             isUnloading={isUnloading}
             oAuthTerminated={oAuthTerminated}
+            onDone={onDone}
             onCancel={() => this.cancel()}
             onSubmit={() => this.onSubmit()}
             submitting={submitting || isRunning}

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -311,7 +311,6 @@ class AccountConnection extends Component {
       displayAccountsCount,
       isUnloading,
       onBack,
-      onNext,
       allRequiredFieldsAreFilled,
       allRequiredFilledButPasswords,
       displayAdvanced,
@@ -332,8 +331,7 @@ class AccountConnection extends Component {
       trigger,
       success,
       closeModal,
-      successButtonLabel,
-      accountsCount
+      successButtonLabel
     } = this.props
     const {
       account,
@@ -385,7 +383,6 @@ class AccountConnection extends Component {
           />
         ) : (
           <KonnectorInstall
-            accountsCount={accountsCount}
             displayAccountsCount={displayAccountsCount}
             isFetching={isFetching}
             onBack={onBack}
@@ -394,7 +391,6 @@ class AccountConnection extends Component {
             isValid={isValid}
             dirty={dirty}
             isSuccess={isSuccess}
-            deleting={deleting}
             disableSuccessTimeout={disableSuccessTimeout}
             driveUrl={driveUrl}
             error={error || oAuthError || connectionError}
@@ -402,9 +398,7 @@ class AccountConnection extends Component {
             queued={queued}
             isUnloading={isUnloading}
             oAuthTerminated={oAuthTerminated}
-            onNext={onNext}
             onCancel={() => this.cancel()}
-            onDelete={() => this.deleteConnection()}
             onSubmit={() => this.onSubmit()}
             submitting={submitting || isRunning}
             success={success || queued}

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -131,7 +131,6 @@ class ConnectionManagement extends Component {
           <AccountConnection
             alertDeleteSuccess={messages => this.alertDeleteSuccess(messages)}
             displayAccountsCount
-            onNext={() => this.gotoParent()}
             onCancel={() => this.gotoParent()}
             isUnloading={isClosing}
             values={values}

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -131,6 +131,7 @@ class ConnectionManagement extends Component {
           <AccountConnection
             alertDeleteSuccess={messages => this.alertDeleteSuccess(messages)}
             displayAccountsCount
+            onDone={this.onDone}
             onCancel={() => this.gotoParent()}
             isUnloading={isClosing}
             values={values}
@@ -158,9 +159,13 @@ class ConnectionManagement extends Component {
     this.gotoParent()
   }
 
-  onBack() {
-    if (this.props.isCreating) {
-      this.props.endCreation()
+  onDone = account => {
+    const { endCreation, isCreating, konnector, history } = this.props
+    if (isCreating) {
+      typeof endCreation === 'function' && endCreation()
+    }
+    if (account) {
+      history.push(`/connected/${konnector.slug}/accounts/${account._id}`)
     }
   }
 


### PR DESCRIPTION
This PR:
* Clean a little bit some props in AccountConnection and related stuff
* Fix the behaviour at the end of an account creation, by using a common `onDone` handler between both ConnectionManagement modal and intent CreateAccountService.

Notice:
Using
```jsx
const render = props => {
  const { foo, bar } = props
  ...
}
```
is better for linting than
```jsx
const render = ({foo, bar}) => {
  ...
}
```