### PR TITLE
OAuth accounts can now be updated

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -190,8 +190,6 @@ export class AccountLoginForm extends React.Component {
                   submitting &&
                   !disableSuccessTimeout &&
                   (editing || !isOAuth || oAuthTerminated)
-                    ? 'true'
-                    : 'false'
                 }
                 onClick={onSubmit}
               >

--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -18,38 +18,37 @@ import ErrorDescription from './ErrorDescriptions'
 
 import warningSvg from '../assets/sprites/icon-warning.svg'
 
-export const KonnectorEdit = ({
-  t,
-  account,
-  connector,
-  deleting,
-  disableSuccessTimeout,
-  allRequiredFieldsAreFilled,
-  allRequiredFilledButPasswords,
-  isValid,
-  isValidButPasswords,
-  dirty,
-  driveUrl,
-  error,
-  fields,
-  folderPath,
-  editing,
-  isFetching,
-  isUnloading,
-  lastSuccess,
-  oAuthTerminated,
-  folders,
-  closeModal,
-  onCancel,
-  onDelete,
-  onForceConnection,
-  onSubmit,
-  submitting,
-  success,
-  trigger,
-  maintenance,
-  lang
-}) => {
+export const KonnectorEdit = props => {
+  const {
+    t,
+    account,
+    connector,
+    deleting,
+    disableSuccessTimeout,
+    allRequiredFieldsAreFilled,
+    allRequiredFilledButPasswords,
+    isValid,
+    isValidButPasswords,
+    dirty,
+    driveUrl,
+    error,
+    fields,
+    editing,
+    isFetching,
+    isUnloading,
+    lastSuccess,
+    oAuthTerminated,
+    folders,
+    closeModal,
+    onDelete,
+    onForceConnection,
+    onSubmit,
+    submitting,
+    trigger,
+    maintenance,
+    lang
+  } = props
+
   const warningIcon = (
     <svg className={styles['item-status-icon']}>
       <use xlinkHref={`#${warningSvg.id}`} /> }

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -91,19 +91,7 @@ class AccountConnection extends Component {
   }
 
   connectAccount(auth) {
-    let { account } = this.state
-
-    if (account) {
-      return this.updateAccount(account, {
-        ...auth
-      })
-    }
-
-    account = {
-      auth
-    }
-
-    return this.runConnection(account).catch(error => this.handleError(error))
+    return this.runConnection({ auth }).catch(error => this.handleError(error))
   }
 
   connectAccountOAuth(accountType, values, scope) {
@@ -272,7 +260,12 @@ class AccountConnection extends Component {
         '_'
       )
     }
+
     // Update account
+    if (account) {
+      return this.updateAccount(account, valuesToSubmit)
+    }
+
     return konnector && konnector.oauth
       ? this.connectAccountOAuth(
           konnector.slug,

--- a/src/containers/AccountConnection.jsx
+++ b/src/containers/AccountConnection.jsx
@@ -367,7 +367,6 @@ class AccountConnection extends Component {
             isUnloading={isUnloading}
             lastSuccess={lastSuccess}
             oAuthTerminated={oAuthTerminated}
-            onCancel={() => this.cancel()}
             onDelete={() => this.deleteConnection()}
             onForceConnection={forceConnection}
             onSubmit={this.onSubmit}
@@ -376,7 +375,6 @@ class AccountConnection extends Component {
             isValid={isValid}
             allRequiredFilledButPasswords={allRequiredFilledButPasswords}
             isValidButPasswords={isValidButPasswords}
-            success={success}
             trigger={trigger}
             closeModal={closeModal}
             dirty={dirty}


### PR DESCRIPTION
When trying to update an account for a OAuth konnector, the OAuth credential window was always popping up, making the use create a new account at every try.
Also, nothing was never updated.

This PR fixes this behaviour.