### PR TITLE
Move new auchandrive connector from collect to registry

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -76,7 +76,7 @@
       }
     },
     "testing": true,
-    "source": "git://github.com/konnectors/auchandrive.git#latest"
+    "source": "registry://auchandrive/stable"
   },
   {
     "slug": "axabanque102",


### PR DESCRIPTION
I put this new connector directly to registry. And keep it in testing for now.
I don't know if all tagged version and publish is exactly right, please check and come back to me if needed.
https://github.com/konnectors/auchandrive/releases