### PR TITLE
Handle konnector i18n from manifest

### DIFF
--- a/src/components/AccountConnectionData.jsx
+++ b/src/components/AccountConnectionData.jsx
@@ -6,23 +6,21 @@ import ClassNames from 'classnames'
 import ReactMarkdownWrapper from '../components/ReactMarkdownWrapper'
 import DataItem from '../components/DataItem'
 
-const AccountConnectionData = ({ t, connector }) => {
-  const { hasDescriptions } = connector
-  const hasDataTypes = !!(connector.data_types && connector.data_types.length)
+import { getKonnectorMessage } from '../lib/konnectors'
 
+const AccountConnectionData = ({ t, connector }) => {
+  const hasDataTypes = !!(connector.data_types && connector.data_types.length)
+  const serviceMessage = getKonnectorMessage(t, connector, 'service')
   return (
     <div className={ClassNames(styles['col-account-connection-data'])}>
-      {hasDescriptions &&
-        hasDescriptions.service && (
-          <div>
-            <h4>{t('account.config.data.service.description')}</h4>
-            <p>
-              <ReactMarkdownWrapper
-                source={t(`connector.${connector.slug}.description.service`)}
-              />
-            </p>
-          </div>
-        )}
+      {serviceMessage && (
+        <div>
+          <h4>{t('account.config.data.service.description')}</h4>
+          <p>
+            <ReactMarkdownWrapper source={serviceMessage} />
+          </p>
+        </div>
+      )}
       <h4>{t('account.config.data.title')}</h4>
       {hasDataTypes && (
         <ul className={styles['col-account-connection-data-access']}>

--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -35,6 +35,16 @@ const hydrateFieldValue = {
 
 const identity = x => x
 
+const FieldDescription = props => {
+  const { field, konnectorSlug, t } = props
+  const hasLegacyDescription = field.hasDescription
+  const descriptionKey = hasLegacyDescription
+    ? `connector.${konnectorSlug}.description.field.${field.name}`
+    : `${konnectorSlug}.${field.description}`
+  if (!descriptionKey) return null
+  return <ReactMarkdownWrapper source={t(descriptionKey)} />
+}
+
 export class AccountLoginForm extends React.Component {
   state = {
     submitEnabled: this.props.isOAuth || false
@@ -130,11 +140,7 @@ export class AccountLoginForm extends React.Component {
       }
       return (
         <div>
-          {field.hasDescription && (
-            <ReactMarkdownWrapper
-              source={t(`connector.${connectorSlug}.description.field.${name}`)}
-            />
-          )}
+          <FieldDescription field={field} konnectorSlug={connectorSlug} t={t} />
           {React.cloneElement(renderers[type](this.props), attributes)}
         </div>
       )

--- a/src/components/DescriptionContent.jsx
+++ b/src/components/DescriptionContent.jsx
@@ -19,7 +19,7 @@ export const DescriptionContent = ({
       {messages &&
         messages.length > 0 &&
         messages.map(m => {
-          return (
+          return m ? (
             <p
               className={classNames(
                 styles['col-account-description-message'],
@@ -28,7 +28,7 @@ export const DescriptionContent = ({
             >
               <ReactMarkdownWrapper source={m} />
             </p>
-          )
+          ) : null
         })}
       {children}
     </div>

--- a/src/components/KonnectorEdit.jsx
+++ b/src/components/KonnectorEdit.jsx
@@ -12,7 +12,7 @@ import KonnectorFolder from './KonnectorFolder'
 import KonnectorMaintenance from './KonnectorMaintenance'
 import KonnectorSync from './KonnectorSync'
 
-import { isKonnectorLoginError } from '../lib/konnectors'
+import { getKonnectorMessage, isKonnectorLoginError } from '../lib/konnectors'
 import { getAccountName } from '../lib/helpers'
 import ErrorDescription from './ErrorDescriptions'
 
@@ -55,7 +55,7 @@ export const KonnectorEdit = props => {
   )
   const hasLoginError = isKonnectorLoginError(error)
   const hasErrorExceptLogin = !!error && !hasLoginError
-  const { hasDescriptions, editor } = connector
+  const { editor } = connector
   // assign accountName placeholder
   if (fields.accountName)
     fields.accountName.placeholder = getAccountName(account)
@@ -122,11 +122,7 @@ export const KonnectorEdit = props => {
           >
             <DescriptionContent
               title={t('account.config.title', { name: connector.name })}
-              messages={
-                hasDescriptions && hasDescriptions.connector
-                  ? [t(`connector.${connector.slug}.description.connector`)]
-                  : []
-              }
+              messages={[getKonnectorMessage(t, connector, 'terms')]}
             />
 
             {

--- a/src/components/KonnectorInstall.jsx
+++ b/src/components/KonnectorInstall.jsx
@@ -8,7 +8,7 @@ import DescriptionContent from './DescriptionContent'
 import KonnectorMaintenance from './KonnectorMaintenance'
 import KonnectorSuccess from './KonnectorSuccess'
 
-import { isKonnectorLoginError } from '../lib/konnectors'
+import { getKonnectorMessage, isKonnectorLoginError } from '../lib/konnectors'
 import ErrorDescription from './ErrorDescriptions'
 
 import securityIcon from '../assets/icons/color/icon-cloud-lock.svg'
@@ -46,7 +46,7 @@ export const KonnectorInstall = props => {
     maintenance,
     lang
   } = props
-  const { hasDescriptions, editor } = connector
+  const { editor } = connector
   const hasLoginError = isKonnectorLoginError(error)
   const hasErrorExceptLogin = !!error && !hasLoginError
   const isRunningInQueue = queued && submitting
@@ -61,11 +61,7 @@ export const KonnectorInstall = props => {
           !maintenance && (
             <DescriptionContent
               title={t('account.config.title', { name: connector.name })}
-              messages={
-                hasDescriptions && hasDescriptions.connector
-                  ? [t(`connector.${connector.slug}.description.connector`)]
-                  : []
-              }
+              messages={[getKonnectorMessage(t, connector, 'terms')]}
             >
               {!connector.oauth &&
                 !error && (

--- a/src/ducks/konnectors/index.js
+++ b/src/ducks/konnectors/index.js
@@ -22,6 +22,7 @@ export const receiveInstalledKonnector = konnector => {
   }
 
   return {
+    doctype: DOCTYPE,
     type: 'RECEIVE_NEW_DOCUMENT',
     response: { data: [normalized] },
     updateCollections: ['konnectors']

--- a/src/lib/konnectors.js
+++ b/src/lib/konnectors.js
@@ -92,3 +92,25 @@ export const getMostAccurateErrorKey = (t, error, getKey = key => key) => {
 
   return tested.length ? fullKey : getKey('UNKNOWN_ERROR')
 }
+
+const legacyMessages = {
+  terms: 'connector'
+}
+
+export const getKonnectorMessage = (t, konnector, message) => {
+  const { messages, hasDescriptions } = konnector
+
+  const providesMessage =
+    messages && messages.length && messages.includes(message)
+  if (providesMessage) return t(`${konnector.slug}.messages.${message}`)
+
+  const providesLegacyMessage =
+    hasDescriptions && hasDescriptions[legacyMessages[message] || message]
+  if (providesLegacyMessage)
+    return t(
+      `connector.${konnector.slug}.description.${legacyMessages[message] ||
+        message}`
+    )
+
+  return null
+}

--- a/src/lib/middlewares/konnectorsI18n.js
+++ b/src/lib/middlewares/konnectorsI18n.js
@@ -1,0 +1,53 @@
+import { extend as extendI18n } from 'cozy-ui/react/I18n'
+
+const KONNECTORS_DOCTYPE = 'io.cozy.konnectors'
+
+const extendI18nWithKonnector = lang => konnector => {
+  const { langs, locales } = konnector
+
+  const hasLangs = langs && langs.length
+  if (!hasLangs) {
+    console.warn &&
+      console.warn(`Konnector ${konnector.name} does not specify any lang`)
+    return konnector
+  }
+
+  const providesLang = hasLangs && langs.includes(lang)
+  const actualLang = providesLang ? lang : langs[0]
+
+  const localeKeys = locales && Object.keys(locales)
+  const providesLocales =
+    localeKeys && localeKeys.length && localeKeys.includes(actualLang)
+
+  if (!providesLocales) {
+    console.warn &&
+      console.warn(
+        `Konnector ${
+          konnector.name
+        } does not specify any locale for lang ${actualLang}`
+      )
+    return konnector
+  }
+
+  extendI18n({ [konnector.slug]: locales[actualLang] })
+  return konnector
+}
+
+export const konnectorsI18nMiddleware = lang => store => next => action => {
+  const { response } = action
+  switch (action.type) {
+    case 'RECEIVE_DATA':
+    case 'RECEIVE_NEW_DOCUMENT':
+      if (response && action.doctype === KONNECTORS_DOCTYPE) {
+        const konnectors = response.data
+        konnectors &&
+          konnectors.length &&
+          konnectors.forEach(extendI18nWithKonnector(lang))
+      }
+      break
+  }
+
+  return next(action)
+}
+
+export default konnectorsI18nMiddleware

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,6 +1,7 @@
 import { compose, createStore, applyMiddleware } from 'redux'
 import { cozyMiddleware } from 'redux-cozy-client'
 import { createLogger } from 'redux-logger'
+import konnectorsI18nMiddleware from '../lib/middlewares/konnectorsI18n'
 import thunkMiddleware from 'redux-thunk'
 
 import CollectStore from '../lib/CollectStore'
@@ -15,6 +16,7 @@ const configureStore = (client, context, options = {}) => {
     composeEnhancers(
       applyMiddleware.apply(this, [
         cozyMiddleware(client),
+        konnectorsI18nMiddleware(options.lang),
         thunkMiddleware,
         createLogger()
       ])

--- a/src/styles/descriptionContent.styl
+++ b/src/styles/descriptionContent.styl
@@ -5,4 +5,4 @@
 .col-account-description-message
     margin .5rem 0
     p
-        margin 0
+        margin .5rem 0

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // store
   const store = configureStore(client, context, {
+    lang,
     ...collectConfig
   })
 

--- a/src/targets/intents/index.jsx
+++ b/src/targets/intents/index.jsx
@@ -25,7 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // store
-  const store = configureStore(client, context)
+  const store = configureStore(client, context, { lang })
 
   render(
     <CozyProvider store={store} client={client}>

--- a/test/lib/konnectors.spec.js
+++ b/test/lib/konnectors.spec.js
@@ -175,4 +175,76 @@ describe('konnectors lib', () => {
       )
     })
   })
+
+  describe('getKonnectorMessage', () => {
+    it('returns expected declared message', () => {
+      const tMock = key => {
+        return {
+          'mykonnector.messages.foo': 'The terms'
+        }[key]
+      }
+
+      const konnector = {
+        messages: ['foo'],
+        slug: 'mykonnector'
+      }
+
+      expect(konnectors.getKonnectorMessage(tMock, konnector, 'foo')).toBe(
+        'The terms'
+      )
+    })
+
+    it('does not return undeclared message', () => {
+      const tMock = key => {
+        return {
+          'mykonnector.messages.foo': 'Bar'
+        }[key]
+      }
+
+      const konnector = {
+        slug: 'mykonnector'
+      }
+
+      expect(konnectors.getKonnectorMessage(tMock, konnector, 'foo')).toBeNull()
+    })
+
+    it('returns legacy message', () => {
+      const tMock = key => {
+        return {
+          'connector.mykonnector.description.foo': 'Bar'
+        }[key]
+      }
+
+      const konnector = {
+        slug: 'mykonnector',
+        hasDescriptions: {
+          foo: true
+        }
+      }
+
+      expect(konnectors.getKonnectorMessage(tMock, konnector, 'foo')).toBe(
+        'Bar'
+      )
+    })
+
+    it('returns legacy mapped message', () => {
+      // 'terms' is mapped to legacy 'connector'
+      const tMock = key => {
+        return {
+          'connector.mykonnector.description.connector': 'The terms'
+        }[key]
+      }
+
+      const konnector = {
+        slug: 'mykonnector',
+        hasDescriptions: {
+          connector: true
+        }
+      }
+
+      expect(konnectors.getKonnectorMessage(tMock, konnector, 'terms')).toBe(
+        'The terms'
+      )
+    })
+  })
 })


### PR DESCRIPTION
This PR deals with konnector i18n information from `manifest.konnector`. To achieve that, it adds a middleware module wich add new locales translation every time a konnector is added to the state (via fetch or realtime).

Alors, it handles and ensures legacy for:
* field attribute 'description' (previously 'hasDescription')
* messages like `terms` or `service` (previously `connector` and `service`)

It allows us to get beautiful modal like this one:

![capture d ecran 2018-05-24 a 17 46 08](https://user-images.githubusercontent.com/776764/40496831-fb222e04-5f7a-11e8-948f-3fea51810a2f.png)

Adding @goldoraf as reviewer for the redux middleware part.
