### PR TITLE
Add temporary lcl-linxo mock

### DIFF
--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -1918,6 +1918,42 @@
     }
   },
   {
+    "slug": "lcl-linxo",
+    "name": "LCL",
+    "categories": ["banking"],
+    "dataType": [
+      "bankAccounts",
+      "bankTransactions"
+    ],
+    "fields": {
+      "bankId": {
+        "type": "dropdown",
+        "label": "branchName",
+        "options": [
+          {
+            "name": "LCL (Particuliers)",
+            "value": "143"
+          },
+          {
+            "name": "e.LCL",
+            "value": "144"
+          },
+          {
+            "name": "LCL (Professionnels)",
+            "value": "146"
+          }
+        ]
+      },
+      "new_identifier": {
+        "type": "text"
+      },
+      "secret": {
+        "type": "password"
+      }
+    },
+    "icon": "lcl.png"
+  },
+  {
     "slug": "lcl143",
     "name": "LCL (Particuliers)",
     "editor": "Cozy Cloud",


### PR DESCRIPTION
To make LCL Linxo valid for migration purpose, we need to add a mock in `konnectors.json`