### PR TITLE
Handle missing data types icon without crashing

### DIFF
--- a/src/components/DataItem.jsx
+++ b/src/components/DataItem.jsx
@@ -4,16 +4,34 @@ import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import Icon from 'cozy-ui/react/Icon'
 
-export const DataItem = ({ t, dataType }) => (
-  <li className={styles['col-data-item']}>
-    <Icon
-      className={styles['col-data-item-icon']}
-      icon={require('../assets/sprites/icon-' + dataType + '.svg').default}
-      width="32px"
-      height="32px"
-    />
-    {t(`dataType.${dataType}`)}
-  </li>
-)
+export const DataItem = ({ t, dataType }) => {
+  const iconPath = '../assets/sprites/icon-' + dataType + '.svg'
+  let icon
+  try {
+    icon = require(iconPath).default
+  } catch (error) {
+    console.error(`Unable to load the icon ${iconPath} : ${error.message}`)
+  }
+
+  if (!icon) {
+    try {
+      icon = require('../assets/sprites/icon-fallback.svg').default
+    } catch (error) {
+      console.error('Default icon icon-fallback.svg cannot be loaded')
+    }
+  }
+
+  return (
+    <li className={styles['col-data-item']}>
+      <Icon
+        className={styles['col-data-item-icon']}
+        icon={icon}
+        width="32px"
+        height="32px"
+      />
+      {t(`dataType.${dataType}`)}
+    </li>
+  )
+}
 
 export default translate()(DataItem)

--- a/src/config/konnectors.json
+++ b/src/config/konnectors.json
@@ -2537,7 +2537,7 @@
     "dataType": [
       "bill",
       "activity",
-      "video_stream"
+      "videostream"
     ],
     "fields": {
       "login": {


### PR DESCRIPTION
When a data type was missing, Collect was stopping doing anything.
This PR handle the case where the related icon is missing.