### PR TITLE
Fix: intro.js css was overwritting

### DIFF
--- a/src/lib/tutorial.js
+++ b/src/lib/tutorial.js
@@ -1,6 +1,5 @@
 import { introJs } from 'intro.js'
 import { shouldEnableTracking, getTracker } from 'cozy-ui/react/helpers/tracker'
-require('../../node_modules/intro.js/minified/introjs.min.css')
 
 export function isTutorial() {
   return window.location.pathname.endsWith('/intro')

--- a/src/targets/browser/index.jsx
+++ b/src/targets/browser/index.jsx
@@ -11,6 +11,7 @@ import PiwikHashRouter from 'lib/PiwikHashRouter'
 import collectConfig from 'config/collect'
 import configureStore from 'store/configureStore'
 
+import 'intro.js/minified/introjs.min.css'
 import 'styles/index.styl'
 
 const lang = document.documentElement.getAttribute('lang') || 'en'


### PR DESCRIPTION
The introjs css was imported after the main styles. Fixed.
<img width="1674" alt="screen shot 2018-06-08 at 11 43 57" src="https://user-images.githubusercontent.com/10224453/41151518-484930f0-6b11-11e8-9410-5d3eef49eafb.png">
