### PR TITLE
Fixed Broken Link In README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Cozy Collect is developed by Cozy Cloud and distributed under the [AGPL v3 licen
 
 
 [cozy]: https://cozy.io "Cozy Cloud"
-[setup]: https://dev.cozy.io/#set-up-the-development-environment "Cozy dev docs: Set up the Development Environment"
+[setup]: https://docs.cozy.io/en/dev/app/#install-the-development-environment "Cozy dev docs: Set up the Development Environment"
 [yarn]: https://yarnpkg.com/
 [yarn-install]: https://yarnpkg.com/en/docs/install
 [cozy-ui]: https://github.com/cozy/cozy-ui


### PR DESCRIPTION
Fixed the link for how to set the development environment in the README.md file.
