### PR TITLE
Fix back button in new account modal

### DIFF
--- a/src/components/InstalledKonnectors.jsx
+++ b/src/components/InstalledKonnectors.jsx
@@ -77,21 +77,13 @@ class InstalledKonnectors extends Component {
           <Route
             path="/connected/:konnectorSlug/new"
             render={props => (
-              <ConnectionManagement
-                backRoute={`/connected/${props.match.params.konnectorSlug}`}
-                originPath="/connected"
-                {...props}
-              />
+              <ConnectionManagement originPath="/connected" {...props} />
             )}
           />
           <Route
             path="/connected/:konnectorSlug/accounts/:accountId"
             render={props => (
-              <ConnectionManagement
-                backRoute={`/connected/${props.match.params.konnectorSlug}`}
-                originPath="/connected"
-                {...props}
-              />
+              <ConnectionManagement originPath="/connected" {...props} />
             )}
           />
           <Redirect from="/connected/*" to="/connected" />

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -166,8 +166,8 @@ class ConnectionManagement extends Component {
     this.gotoParent()
   }
 
-  onDone = account => {
-    const { endCreation, isCreating, konnector, history } = this.props
+  onDone = event => {
+    const { account, endCreation, isCreating, konnector, history } = this.props
     if (isCreating) {
       typeof endCreation === 'function' && endCreation()
     }

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -98,11 +98,20 @@ class ConnectionManagement extends Component {
   }
 
   render() {
-    const { backRoute, createdAccount, existingAccount, konnector } = this.props
+    const {
+      connections,
+      createdAccount,
+      existingAccount,
+      konnector
+    } = this.props
     // Do not even render if there is no konnector (in case of wrong URL)
     if (!konnector) return
 
     const { isClosing, values } = this.state
+
+    const backRoute = connections.length
+      ? `/connected/${konnector.slug}`
+      : '/connected'
 
     return (
       <Modal

--- a/src/containers/ConnectionManagement.jsx
+++ b/src/containers/ConnectionManagement.jsx
@@ -98,14 +98,7 @@ class ConnectionManagement extends Component {
   }
 
   render() {
-    const {
-      backRoute,
-      connections,
-      createdAccount,
-      existingAccount,
-      getBackRoute,
-      konnector
-    } = this.props
+    const { backRoute, createdAccount, existingAccount, konnector } = this.props
     // Do not even render if there is no konnector (in case of wrong URL)
     if (!konnector) return
 
@@ -120,9 +113,9 @@ class ConnectionManagement extends Component {
       >
         <ModalHeader>
           <div className={styles['col-account-connection-header']}>
-            {(backRoute || getBackRoute) && (
+            {backRoute && (
               <NavLink
-                to={backRoute || getBackRoute(connections)}
+                to={backRoute}
                 className={styles['col-account-connection-back']}
                 onClick={this.onDone}
               >


### PR DESCRIPTION
After fixing the disappearing fields issue, the back button in the account creation modal was not working effectively in case of a konnector with no accounts.

This PR fixes this issue.