### PR TITLE
Add missing back button on account picker

### DIFF
--- a/src/components/AccountPicker.jsx
+++ b/src/components/AccountPicker.jsx
@@ -16,6 +16,8 @@ import AccountPickerItem from './AccountPickerItem'
 import KonnectorHeaderIcon from './KonnectorHeaderIcon'
 import addAccountIcon from '../assets/icons/icon-plus.svg'
 
+import backIcon from '../assets/sprites/icon-arrow-left.svg'
+
 export const AccountPicker = ({
   t,
   connections,
@@ -29,6 +31,12 @@ export const AccountPicker = ({
   return (
     <Modal dismissAction={() => history.push('/connected')} mobileFullscreen>
       <ModalHeader>
+        <NavLink
+          to="/connected"
+          className={styles['col-account-connection-back']}
+        >
+          <Icon icon={backIcon} />
+        </NavLink>
         <KonnectorHeaderIcon konnector={konnector} />
       </ModalHeader>
       <ModalContent>


### PR DESCRIPTION
- Knock Knock
- Who's there ?
- Another bugfix related to [disappearing fields values issue](https://github.com/cozy/cozy-collect/pull/821). This time the back button on Account Picker was simply missing, I did not spot the commit responsible of its absence.