### PR TITLE
Handle trigger cron with hours set to 0 without making it hourly

### DIFF
--- a/src/ducks/triggers/index.js
+++ b/src/ducks/triggers/index.js
@@ -67,6 +67,14 @@ export const buildTriggerFrequencyOptions = (konnector, options) => {
   return frequencyOptions
 }
 
+function isInteger(value) {
+  return (
+    typeof value === 'number' &&
+    Math.floor(value) === value &&
+    parseInt(value, 10) === value
+  )
+}
+
 export function buildKonnectorTrigger(
   konnector,
   account,
@@ -91,7 +99,9 @@ export function buildKonnectorTrigger(
     _type: DOCTYPE,
     attributes: {
       type: '@cron',
-      arguments: `0 ${minutes || 0} ${hours || '*'} * * ${day || '*'}`,
+      arguments: `0 ${isInteger(minutes) ? minutes : 0} ${
+        isInteger(hours) ? hours : '*'
+      } * * ${isInteger(day) ? day : '*'}`,
       worker: 'konnector',
       worker_arguments: workerArguments
     }

--- a/src/ducks/triggers/test/__snapshots__/triggers.spec.js.snap
+++ b/src/ducks/triggers/test/__snapshots__/triggers.spec.js.snap
@@ -44,6 +44,36 @@ Object {
 }
 `;
 
+exports[`Trigger Duck buildKonnectorTrigger creates a trigger with day set to 0 1`] = `
+Object {
+  "_type": "io.cozy.triggers",
+  "attributes": Object {
+    "arguments": "0 15 14 * * *",
+    "type": "@cron",
+    "worker": "konnector",
+    "worker_arguments": Object {
+      "account": "963a51f6cdd34401b0904de32cc5578d",
+      "konnector": "test",
+    },
+  },
+}
+`;
+
+exports[`Trigger Duck buildKonnectorTrigger creates a trigger with hours set to 0 1`] = `
+Object {
+  "_type": "io.cozy.triggers",
+  "attributes": Object {
+    "arguments": "0 15 0 * * *",
+    "type": "@cron",
+    "worker": "konnector",
+    "worker_arguments": Object {
+      "account": "963a51f6cdd34401b0904de32cc5578d",
+      "konnector": "test",
+    },
+  },
+}
+`;
+
 exports[`Trigger Duck buildKonnectorTrigger creates a trigger without folder 1`] = `
 Object {
   "_type": "io.cozy.triggers",

--- a/src/ducks/triggers/test/triggers.spec.js
+++ b/src/ducks/triggers/test/triggers.spec.js
@@ -40,6 +40,24 @@ describe('Trigger Duck', () => {
         buildKonnectorTrigger(hourlyKonnector, account, null, options)
       ).toMatchSnapshot()
     })
+
+    it('creates a trigger with day set to 0', () => {
+      const dailyKonnector = { ...konnector, frequency: 'daily' }
+      const dailyOptions = { ...options, day: 0 }
+
+      expect(
+        buildKonnectorTrigger(dailyKonnector, account, null, dailyOptions)
+      ).toMatchSnapshot()
+    })
+
+    it('creates a trigger with hours set to 0', () => {
+      const dailyKonnector = { ...konnector, frequency: 'daily' }
+      const dailyOptions = { ...options, hours: 0 }
+
+      expect(
+        buildKonnectorTrigger(dailyKonnector, account, null, dailyOptions)
+      ).toMatchSnapshot()
+    })
   })
 
   describe('buildTriggerFrequencyOptions', () => {


### PR DESCRIPTION
Some konnectors, sometimes, were runned with an hourly frequency instead of a daily one. But it was not reproductible.

After investigation, it appears that randomizing an `hours` value may make it to be `0`.
In the code, a `0` value was considered as falsy and was replace by an `*`, making the cron to be hourly.