### PR TITLE
Fix margin in interapp iframe

### DIFF
--- a/src/styles/services.styl
+++ b/src/styles/services.styl
@@ -94,7 +94,6 @@
             background-position  center right
 
     .coz-service-content
-        width 100%
         flex-grow 1
         display flex
         max-height      calc(100vh - (32/basefont)em)
@@ -102,5 +101,5 @@
         padding (16/basefont)em 0
         flex-direction column
         align-items center
-        margin auto
+        margin 0 (16/basefont)em
         overflow-y auto


### PR DESCRIPTION
Margin was `auto` and it was pretty ugly in interapp iframe.


![capture d ecran 2018-06-13 a 18 09 39](https://user-images.githubusercontent.com/776764/41363736-fe2dcd96-6f34-11e8-89b6-d9b5226c0e83.png)
