### PR TITLE
Fix password update error

### DIFF
--- a/src/lib/accounts.js
+++ b/src/lib/accounts.js
@@ -10,12 +10,8 @@ export const ACCOUNT_ERRORS = {
 }
 
 export function update(cozy, account, newAccount) {
-  // Fetch the current account to get the correct _rev attribute.
-  // It may have changed, if a job has been running for example.
-  return cozy.data.find(ACCOUNTS_DOCTYPE, account._id).then(currentAccount => {
-    return cozy.data.updateAttributes(ACCOUNTS_DOCTYPE, account.id, {
-      auth: newAccount.auth
-    })
+  return cozy.data.updateAttributes(ACCOUNTS_DOCTYPE, account._id, {
+    auth: newAccount.auth
   })
 }
 

--- a/test/lib/accounts.spec.js
+++ b/test/lib/accounts.spec.js
@@ -71,7 +71,7 @@ describe('accounts library', () => {
           accounts.ACCOUNTS_DOCTYPE
         )
         expect(cozyMock.data.updateAttributes.mock.calls[0][1]).toEqual(
-          accountMock.id
+          accountMock._id
         )
         expect(cozyMock.data.updateAttributes.mock.calls[0][2]).toEqual({
           auth: accountMock2.auth


### PR DESCRIPTION
Second password update was throwing an error caused by undefined id. This PR cleans the update method and remove the reference to `account.id`.

My `debug` konnector is failing miserabily locally but Trainline seems to work.