### PR TITLE
Get the check mark back on konnector tiles

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -5,7 +5,6 @@ import { translate } from 'cozy-ui/react/I18n'
 import { NavLink, withRouter } from 'react-router-dom'
 
 import { getKonnectorIcon } from '../lib/icons'
-import { getKonnectorTriggersCount } from '../reducers'
 import { hasAtLeastOneTriggerWithUserError } from '../ducks/connections'
 
 const KonnectorTile = ({
@@ -30,23 +29,8 @@ const KonnectorTile = ({
       </header>
       <h3 className="item-title">{konnector.name}</h3>
       {subtitle && <p className="item-subtitle">{subtitle}</p>}
-      <KonnectorTileFooter
-        accountsCount={accountsCount}
-        hasUserError={hasUserError}
-        title={t('connector.accounts_count', { count: accountsCount })}
-      />
+      {hasUserError ? svgIcon('warning') : svgIcon('check')}
     </NavLink>
-  )
-}
-
-const KonnectorTileFooter = ({ accountsCount, hasUserError, title }) => {
-  if (hasUserError) return svgIcon('warning')
-  if (!accountsCount) return svgIcon('new')
-
-  return (
-    <span className="item-count" title={title}>
-      {accountsCount}
-    </span>
   )
 }
 
@@ -61,7 +45,6 @@ const svgIcon = name => (
 const mapStateToProps = (state, props) => {
   const { konnector } = props
   return {
-    accountsCount: getKonnectorTriggersCount(state, konnector),
     hasUserError: hasAtLeastOneTriggerWithUserError(
       state.connections,
       konnector.slug

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -362,7 +362,6 @@
     "no-connectors-connected": "You have not yet connected connectors",
     "get-info": "Get automatically all your informations in your Cozy",
     "connect-account": "Connect my accounts",
-    "accounts_count": "%{count} connected accounts",
     "logo": {
       "alt": "%{name} logo"
     },


### PR DESCRIPTION
Replacing account count by a green check mark.

The logic and method to get accounts count is still used in the edition modal, so let's keep it.

![capture d ecran 2018-06-20 a 11 12 42](https://user-images.githubusercontent.com/776764/41649067-e32247ac-747a-11e8-9b40-7f148fb2ee64.png)
