### PR TITLE
Handle intent redirections for konnector accounts

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -81,6 +81,11 @@
     "action": "CREATE",
     "type": ["io.cozy.accounts"],
     "href": "/intents"
+  }, {
+    "action": "REDIRECT",
+    "type": ["io.cozy.accounts"],
+    "href": "/redirect",
+    "data": ["konnector"]
   }],
   "services": {
    "clean-orphan-accounts": {

--- a/src/components/IntentRedirect.jsx
+++ b/src/components/IntentRedirect.jsx
@@ -1,0 +1,38 @@
+/* global cozy */
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+
+import { connect } from 'react-redux'
+import { getInstalledKonnectors } from '../reducers'
+
+const IntentRedirect = ({ installedKonnectors, location }) => {
+  const queryString = !!location && location.search
+  const query =
+    queryString &&
+    queryString
+      .substring(1)
+      .split('&')
+      .reduce((accumulator, keyValue) => {
+        const splitted = keyValue.split('=')
+        accumulator[splitted[0]] = splitted[1] || true
+        return accumulator
+      }, {})
+
+  if (query.konnector) {
+    if (
+      installedKonnectors.find(konnector => konnector.slug === query.konnector)
+    ) {
+      return <Redirect to={`/connected/${query.konnector}`} />
+    } else {
+      cozy.client.intents.redirect('io.cozy.apps', { slug: query.konnector })
+    }
+  }
+
+  return <Redirect to={`/connected`} />
+}
+
+const mapStateToProps = (state, ownProps) => ({
+  installedKonnectors: getInstalledKonnectors(state)
+})
+
+export default connect(mapStateToProps)(IntentRedirect)

--- a/src/containers/App.jsx
+++ b/src/containers/App.jsx
@@ -10,6 +10,7 @@ import Failure from '../components/Failure'
 import ConnectionsQueue from '../ducks/connections/components/queue/index'
 
 import InstalledKonnectors from '../components/InstalledKonnectors'
+import IntentRedirect from '../components/IntentRedirect'
 import StoreRedirection from '../components/StoreRedirection'
 
 class App extends Component {
@@ -49,6 +50,7 @@ class App extends Component {
             }}
           >
             <Switch>
+              <Route path="/redirect" component={IntentRedirect} />
               <Route
                 path="/connected"
                 render={props => (


### PR DESCRIPTION
Quick implementation of intent redirection for collect.

In the future it should be mutualized wiht cozy-store (see https://github.com/cozy/cozy-store/pull/262) same component and embeded into cozy-interapp lib.