### PR TITLE
Avoid form submit event to bubble up

### DIFF
--- a/src/components/KonnectorSuccess.jsx
+++ b/src/components/KonnectorSuccess.jsx
@@ -65,7 +65,8 @@ export const KonnectorSuccess = props => {
             <p>
               <Button
                 label={successButtonLabel || t('account.success.button.config')}
-                onClick={() => {
+                onClick={event => {
+                  event.preventDefault()
                   onDone(account)
                 }}
               />


### PR DESCRIPTION
Clicking on "Access my account configuration" was also submitting the save folder form.