### PR TITLE
Avoid duplicate CSS property col-top-bar

### DIFF
--- a/src/components/InstalledKonnectors.jsx
+++ b/src/components/InstalledKonnectors.jsx
@@ -46,7 +46,7 @@ class InstalledKonnectors extends Component {
     return (
       <Main>
         <ScrollToTopOnMount target={wrapper} />
-        <div className="col-top-bar" data-tutorial="top-bar">
+        <div className="col-content col-top-bar" data-tutorial="top-bar">
           {isMobile ? <BarCenter>{title}</BarCenter> : title}
         </div>
         <Content className="col-content">

--- a/src/styles/app.styl
+++ b/src/styles/app.styl
@@ -5,7 +5,6 @@
 
 
 .col-content
-.col-top-bar
     padding 0 2rem
 
     +small-screen()


### PR DESCRIPTION
Prevent
```
src/styles/app.styl
21  error  duplicate property or selector, consider merging see file: src/styles/app.styl for the original selector  duplicates
```