### PR TITLE
Log warning instead of throwing error on unexpected field type

### DIFF
--- a/src/components/AccountLoginForm.jsx
+++ b/src/components/AccountLoginForm.jsx
@@ -119,7 +119,8 @@ export class AccountLoginForm extends React.Component {
     const renderField = field => {
       const { name, label, type, value, placeholder } = field
       if (!renderers[type]) {
-        throw new Error('Unknown field type ' + type)
+        console.warn && console.warn('Unknown field type ' + type)
+        return null
       }
       const disabled = probableLoginFieldNames.includes(name) && editing
 


### PR DESCRIPTION
Avoid throwing an error when a konnector field has an unexpected type. Otherwise the whole edition modal is not displayed and it looks like a critical crash.