### PR TITLE
Automate the bump version commit when starting a new release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,6 +17,15 @@ branch_name="release-${version}"
 echo "Checking out to $branch_name"
 git checkout -b $branch_name
 git commit --allow-empty -m "chore: starting release ${version}"
+
+jq '.version = $version' --arg version $version package.json > package.temp.json && mv package.temp.json package.json
+jq '.version = $version' --arg version $version manifest.webapp > manifest.temp.webapp && mv manifest.temp.webapp manifest.webapp
+
+git add package.json
+git add manifest.webapp
+
+git commit -m "📦 chore: bump version ${version}"
+
 git push -u origin HEAD
 
 release_pr_template="./scripts/release-pr-template.txt"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+command -v jq >/dev/null 2>&1 || { echo >&2 "jq is required but it's not installed. Aborting."; exit 1; }
+
 echo "Starting the release process..."
 
 current_version=$(cat package.json | jq -rc '.version')


### PR DESCRIPTION
This PR automates the first bump version commit when starting a new release and avoid human errors, event if the version bump is in the checklist.