### PR TITLE
Do no copy private key in Travis build for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ cache:
   directories:
   - node_modules
 before_install:
-- openssl aes-256-cbc -K $encrypted_8431ed5600b0_key -iv $encrypted_8431ed5600b0_iv -in ./scripts/id_rsa.enc -out /tmp/deploy_rsa -d
-- eval "$(ssh-agent -s)"
-- chmod 600 /tmp/deploy_rsa
-- ssh-add /tmp/deploy_rsa
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then openssl aes-256-cbc -K $encrypted_8431ed5600b0_key -iv $encrypted_8431ed5600b0_iv -in ./scripts/id_rsa.enc -out /tmp/deploy_rsa -d; fi'
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then eval "$(ssh-agent -s)"; fi'
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then chmod 600 /tmp/deploy_rsa; fi'
+- 'if [ "$TRAVIS_SECURE_ENV_VARS" != "false" ]; then ssh-add /tmp/deploy_rsa; fi'
 - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
 - export PATH="$HOME/.yarn/bin:$PATH"
 - curl -fsSL https://bootstrap.pypa.io/get-pip.py | python3.5 - --user


### PR DESCRIPTION
This PR try to make the build works for PR from forks, as forks cannot access to Travis secured vars.