### PR TITLE
Avoid unknown category in KonnectorTile

### DIFF
--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -8,6 +8,8 @@ import { getKonnectorIcon } from '../lib/icons'
 import { getKonnectorTriggersCount } from '../reducers'
 import { hasAtLeastOneTriggerWithUserError } from '../ducks/connections'
 
+const validCategoriesSet = new Set(require('../config/categories'))
+
 const KonnectorTileFooter = ({ accountsCount, hasUserError, subtitle, t }) =>
   accountsCount ? (
     <div>
@@ -25,10 +27,13 @@ const KonnectorTile = ({
   route,
   t
 }) => {
-  const categories = konnector.categories
-    ? konnector.categories.map(c => t(`category.${c}`))
-    : []
-  const subtitle = categories.join(', ')
+  const categoriesSet = konnector.categories
+    ? konnector.categories
+        .map(c => (validCategoriesSet.has(c) ? c : 'other'))
+        .reduce((acc, c) => acc.add(c), new Set())
+    : new Set()
+  const subtitle =
+    categoriesSet && [...categoriesSet].map(c => t(`category.${c}`)).join(', ')
   return (
     <NavLink className="item-wrapper" to={route}>
       <header className="item-header">


### PR DESCRIPTION
![capture du 2018-06-26 15-00-31](https://user-images.githubusercontent.com/776764/41926031-7736aef4-796e-11e8-9f07-fec8a170b2d9.png)

Unknown category was displayed.

This PR fixes this and ensure that a category, including _Other_ category, is not mentioned twice in the Tile.

So

![capture d ecran 2018-06-26 a 18 27 32](https://user-images.githubusercontent.com/776764/41926092-a3dfafd2-796e-11e8-9083-76b731046549.png)

will display:

![capture d ecran 2018-06-26 a 18 28 20](https://user-images.githubusercontent.com/776764/41926116-babef79e-796e-11e8-951e-bedc3cd2397c.png)
