### PR TITLE
Add neutral status in konnector tile

### DIFF
--- a/src/assets/sprites/icon-forbidden.svg
+++ b/src/assets/sprites/icon-forbidden.svg
@@ -1,0 +1,11 @@
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs>
+        <path d="M3.13067847,4.49357124 C2.41919963,5.47985789 2,6.69097429 2,8 C2,11.3137085 4.6862915,14 8,14 C9.30902571,14 10.5201421,13.5808004 11.5064288,12.8693215 L3.13067847,4.49357124 Z M4.49357124,3.13067847 L12.8693215,11.5064288 C13.5808004,10.5201421 14,9.30902571 14,8 C14,4.6862915 11.3137085,2 8,2 C6.69097429,2 5.47985789,2.41919963 4.49357124,3.13067847 Z M8,16 C3.581722,16 0,12.418278 0,8 C0,3.581722 3.581722,0 8,0 C12.418278,0 16,3.581722 16,8 C16,12.418278 12.418278,16 8,16 Z" id="path-1"></path>
+    </defs>
+    <g id="icons/16/forbidden" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <mask id="mask-2" fill="white">
+            <use xlink:href="#path-1"></use>
+        </mask>
+        <use id="Mask" fill="#95999d" fill-rule="nonzero" xlink:href="#path-1"></use>
+    </g>
+</svg>

--- a/src/components/KonnectorTile.jsx
+++ b/src/components/KonnectorTile.jsx
@@ -6,15 +6,26 @@ import { NavLink, withRouter } from 'react-router-dom'
 
 import { getKonnectorIcon } from '../lib/icons'
 import { getKonnectorTriggersCount } from '../reducers'
-import { hasAtLeastOneTriggerWithUserError } from '../ducks/connections'
+import {
+  hasAtLeastOneTriggerWithError,
+  hasAtLeastOneTriggerWithUserError
+} from '../ducks/connections'
 
 const validCategoriesSet = new Set(require('../config/categories'))
 
-const KonnectorTileFooter = ({ accountsCount, hasUserError, subtitle, t }) =>
+const KonnectorTileFooter = ({
+  accountsCount,
+  hasError,
+  hasUserError,
+  subtitle,
+  t
+}) =>
   accountsCount ? (
     <div>
       {!!subtitle && <p className="item-subtitle">{subtitle}</p>}
-      {hasUserError ? svgIcon('warning') : svgIcon('check')}
+      {hasUserError
+        ? svgIcon('warning')
+        : hasError ? svgIcon('forbidden') : svgIcon('check')}
     </div>
   ) : (
     <span className="item-subtitle-no-account">{t('connector.noAccount')}</span>
@@ -22,6 +33,7 @@ const KonnectorTileFooter = ({ accountsCount, hasUserError, subtitle, t }) =>
 
 const KonnectorTile = ({
   accountsCount,
+  hasError,
   hasUserError,
   konnector,
   route,
@@ -46,6 +58,7 @@ const KonnectorTile = ({
       <h3 className="item-title">{konnector.name}</h3>
       <KonnectorTileFooter
         accountsCount={accountsCount}
+        hasError={hasError}
         hasUserError={hasUserError}
         subtitle={subtitle}
         t={t}
@@ -66,6 +79,7 @@ const mapStateToProps = (state, props) => {
   const { konnector } = props
   return {
     accountsCount: getKonnectorTriggersCount(state, konnector),
+    hasError: hasAtLeastOneTriggerWithError(state.connections, konnector.slug),
     hasUserError: hasAtLeastOneTriggerWithUserError(
       state.connections,
       konnector.slug

--- a/src/ducks/connections/index.js
+++ b/src/ducks/connections/index.js
@@ -335,6 +335,17 @@ export const launchTriggerAndQueue = (trigger, delay = DEFAULT_QUEUE_DELAY) => (
 }
 
 // Helpers
+export const hasAtLeastOneTriggerWithError = (state, konnectorSlug) => {
+  return (
+    !!state.konnectors &&
+    !!state.konnectors[konnectorSlug] &&
+    !!state.konnectors[konnectorSlug].triggers &&
+    !!Object.values(state.konnectors[konnectorSlug].triggers).find(
+      trigger => !!trigger.error
+    )
+  )
+}
+
 export const hasAtLeastOneTriggerWithUserError = (state, konnectorSlug) => {
   return (
     !!state.konnectors &&


### PR DESCRIPTION
Neutral status is shown when a konnector have an errored trigger but no user error.

![capture d ecran 2018-07-04 a 16 08 41](https://user-images.githubusercontent.com/776764/42281700-a8e6148a-7fa4-11e8-9900-5c381705b316.png)
