### PR TITLE
feat(locales): Add appKey and appSecret fields

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,6 +35,8 @@
         "login": "Login",
         "consumerKey": "Consumer Key",
         "consumerSecret": "Consumer Secret",
+        "appKey": "Application Key",
+        "appSecret": "Application Secret",
         "tricountUrl": "Tricount URL",
         "cardNumber": "Card Number",
         "dob": "Date of birth",


### PR DESCRIPTION
Requiring some new fields for Ovh connector.
(Will reuse 'consumerKey' too)